### PR TITLE
Positional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ Procedures with incompatible inputs will be returned in the `ignoredProcedures` 
 Here's a more involved example, along with what it outputs:
 
 <!-- codegen:start {preset: custom, require: tsx/cjs, source: ./readme-codegen.ts, export: dump, file: test/fixtures/calculator.ts} -->
-<!-- hash:b63bdbb21d0708bc6ce34e408c58f249 -->
+<!-- hash:ae42f01a6ea72021b5bc7f4823803c9f -->
 ```ts
 import * as trpcServer from '@trpc/server'
-import {TrpcCliMeta, trpcCli} from 'trpc-cli'
+import {trpcCli, type TrpcCliMeta} from 'trpc-cli'
 import {z} from 'zod'
 
 const trpc = trpcServer.initTRPC.meta<TrpcCliMeta>().create()
@@ -356,10 +356,10 @@ You could also override `process.exit` to avoid killing the process at all - see
 Given a migrations router looking like this:
 
 <!-- codegen:start {preset: custom, require: tsx/cjs, source: ./readme-codegen.ts, export: dump, file: test/fixtures/migrations.ts} -->
-<!-- hash:57e812de50ced6dc1150ebe5498d5ecd -->
+<!-- hash:99a33a561c51e15dddf7c57da43d3b72 -->
 ```ts
 import * as trpcServer from '@trpc/server'
-import {TrpcCliMeta, trpcCli} from 'trpc-cli'
+import {trpcCli, type TrpcCliMeta} from 'trpc-cli'
 import {z} from 'zod'
 
 const trpc = trpcServer.initTRPC.meta<TrpcCliMeta>().create()

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "pnpm build",
     "lint": "eslint .",
     "build": "tsc -p tsconfig.lib.json",
+    "dev": "cd test/fixtures && tsx",
     "test": "vitest run"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,50 +1,34 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import {Procedure, Router, TRPCError, inferRouterContext, initTRPC} from '@trpc/server'
+import {Procedure, Router, TRPCError, initTRPC} from '@trpc/server'
 import * as cleye from 'cleye'
 import colors from 'picocolors'
-import {ZodError, z} from 'zod'
-import zodToJsonSchema, {JsonSchema7ObjectType, type JsonSchema7Type} from 'zod-to-json-schema'
+import {ZodError} from 'zod'
+import {type JsonSchema7Type} from 'zod-to-json-schema'
 import * as zodValidationError from 'zod-validation-error'
+import {flattenedProperties, incompatiblePropertyPairs, getDescription} from './json-schema'
+import {TrpcCliParams} from './types'
+import {parseProcedureInputs} from './zod-procedure'
 
-export type TrpcCliParams<R extends Router<any>> = {
-  router: R
-  context?: inferRouterContext<R>
-  alias?: (fullName: string, meta: {command: string; flags: Record<string, unknown>}) => string | undefined
-}
-
-/**
- * Optional interface for describing procedures via meta - if your router conforms to this meta shape, it will contribute to the CLI help text.
- * Based on @see `import('cleye').HelpOptions`
- */
-export interface TrpcCliMeta {
-  /** Version of the script displayed in `--help` output. Use to avoid enabling `--version` flag. */
-  version?: string
-  /** Description of the script or command to display in `--help` output. */
-  description?: string
-  /** Usage code examples to display in `--help` output. */
-  usage?: false | string | string[]
-  /** Example code snippets to display in `--help` output. */
-  examples?: string | string[]
-}
+export * from './types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const trpcCli = <R extends Router<any>>({router, context, alias}: TrpcCliParams<R>) => {
-  const procedures = Object.entries(router._def.procedures).map(([commandName, value]) => {
-    const procedure = value as Procedure<any, any>
-    const procedureResult = parseProcedureInputs(procedure)
-    if (!procedureResult.success) {
-      return [commandName, procedureResult.error] as const
-    }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const procedures = Object.entries<Procedure<any, any>>(router._def.procedures as {}).map(
+    ([commandName, procedure]) => {
+      const procedureResult = parseProcedureInputs(procedure)
+      if (!procedureResult.success) {
+        return [commandName, procedureResult.error] as const
+      }
 
-    const jsonSchema = procedureResult.value
-    const properties = flattenedProperties(jsonSchema.flagsSchema)
-    const incompatiblePairs = incompatiblePropertyPairs(jsonSchema.flagsSchema)
-    const type = router._def.procedures[commandName]._def.mutation ? 'mutation' : 'query'
+      const jsonSchema = procedureResult.value
+      const properties = flattenedProperties(jsonSchema.flagsSchema)
+      const incompatiblePairs = incompatiblePropertyPairs(jsonSchema.flagsSchema)
+      const type = router._def.procedures[commandName]._def.mutation ? 'mutation' : 'query'
 
-    return [commandName, {procedure, jsonSchema, properties, incompatiblePairs, type}] as const
-  })
+      return [commandName, {procedure, jsonSchema, properties, incompatiblePairs, type}] as const
+    },
+  )
 
   const procedureEntries = procedures.flatMap(([k, v]) => {
     return typeof v === 'string' ? [] : [[k, v] as const]
@@ -90,7 +74,7 @@ export const trpcCli = <R extends Router<any>>({router, context, alias}: TrpcCli
                 {
                   type: cleyeType,
                   description,
-                  default: propertyValue.default,
+                  default: propertyValue.default as {},
                 },
               ]
             }),
@@ -105,7 +89,7 @@ export const trpcCli = <R extends Router<any>>({router, context, alias}: TrpcCli
 
           return cleye.command({
             name: commandName,
-            help: procedure.meta,
+            help: procedure.meta as {},
             parameters: jsonSchema.parameters,
             flags: flags as {},
           })
@@ -115,7 +99,7 @@ export const trpcCli = <R extends Router<any>>({router, context, alias}: TrpcCli
       params?.argv,
     )
 
-    const {verboseErrors: _verboseErrors, ...unknownFlags} = parsedArgv.unknownFlags
+    const {verboseErrors: _verboseErrors, ...unknownFlags} = parsedArgv.unknownFlags as Record<string, unknown>
     verboseErrors = _verboseErrors || parsedArgv.flags.verboseErrors
 
     const caller = initTRPC.context<NonNullable<typeof context>>().create({}).createCallerFactory(router)(context)
@@ -148,12 +132,12 @@ export const trpcCli = <R extends Router<any>>({router, context, alias}: TrpcCli
 
     if (Object.entries(unknownFlags).length > 0) {
       const s = Object.entries(unknownFlags).length === 1 ? '' : 's'
-      return die(`Unexpected flag${s}: ${Object.keys(parsedArgv.unknownFlags).join(', ')}`)
+      return die(`Unexpected flag${s}: ${Object.keys(unknownFlags).join(', ')}`)
     }
 
     let {help, ...flags} = parsedArgv.flags
 
-    flags = Object.fromEntries(Object.entries(flags).filter(([_k, v]) => v !== undefined)) // cleye returns undefined for flags which didn't receive a value
+    flags = Object.fromEntries(Object.entries(flags as {}).filter(([_k, v]) => v !== undefined)) // cleye returns undefined for flags which didn't receive a value
 
     const incompatibleMessages = procedureInfo.incompatiblePairs
       .filter(([a, b]) => a in flags && b in flags)
@@ -231,239 +215,4 @@ function getCleyeType(schema: JsonSchema7Type) {
       return (value: unknown) => value
     }
   }
-}
-
-const capitaliseFromCamelCase = (camel: string) => {
-  const parts = camel.split(/(?=[A-Z])/)
-  return capitalise(parts.map(p => p.toLowerCase()).join(' '))
-}
-
-const capitalise = (s: string) => s.slice(0, 1).toUpperCase() + s.slice(1)
-
-const flattenedProperties = (sch: JsonSchema7Type): JsonSchema7ObjectType['properties'] => {
-  if ('properties' in sch) {
-    return sch.properties
-  }
-  if ('allOf' in sch) {
-    return Object.fromEntries(
-      sch.allOf!.flatMap(subSchema => Object.entries(flattenedProperties(subSchema as JsonSchema7Type))),
-    )
-  }
-  if ('anyOf' in sch) {
-    const isExcluded = (v: JsonSchema7Type) => Object.keys(v).join(',') === 'not'
-    const entries = sch.anyOf!.flatMap(subSchema => {
-      const flattened = flattenedProperties(subSchema as JsonSchema7Type)
-      const excluded = Object.entries(flattened).flatMap(([name, propSchema]) => {
-        return isExcluded(propSchema) ? [`--${name}`] : []
-      })
-      return Object.entries(flattened).map(([k, v]): [typeof k, typeof v] => {
-        if (!isExcluded(v) && excluded.length > 0) {
-          return [k, Object.assign({}, v, {'Do not use with': excluded}) as typeof v]
-        }
-        return [k, v]
-      })
-    })
-
-    return Object.fromEntries(
-      entries.sort((a, b) => {
-        const scores = [a, b].map(([_k, v]) => (isExcluded(v) ? 0 : 1)) // Put the excluded ones first, so that `Object.fromEntries` will override them with the non-excluded ones (`Object.fromEntries([['a', 1], ['a', 2]])` => `{a: 2}`)
-        return scores[0] - scores[1]
-      }),
-    )
-  }
-  return {}
-}
-
-/** For a union type, returns a list of pairs of properties which *shouldn't* be used together (because they don't appear in the same type variant) */
-const incompatiblePropertyPairs = (sch: JsonSchema7Type): Array<[string, string]> => {
-  const isUnion = 'anyOf' in sch
-  if (!isUnion) return []
-
-  const sets = sch.anyOf!.map(subSchema => {
-    const keys = Object.keys(flattenedProperties(subSchema as JsonSchema7Type))
-    return {keys, set: new Set(keys)}
-  })
-
-  const compatiblityEntries = sets.flatMap(({keys}) => {
-    return keys.map(key => {
-      return [key, new Set(sets.filter(other => other.set.has(key)).flatMap(other => other.keys))] as const
-    })
-  })
-  const allKeys = sets.flatMap(({keys}) => keys)
-
-  return compatiblityEntries.flatMap(([key, compatibleWith]) => {
-    const incompatibleEntries = allKeys
-      .filter(other => key < other && !compatibleWith.has(other))
-      .map((other): [string, string] => [key, other])
-    return incompatibleEntries
-  })
-}
-
-/**
- * Tries fairly hard to build a roughly human-readable description of a json-schema type.
- * A few common properties are given special treatment, most others are just stringified and output in `key: value` format.
- */
-const getDescription = (v: JsonSchema7Type): string => {
-  if ('items' in v) {
-    return [getDescription(v.items as JsonSchema7Type), '(array)'].filter(Boolean).join(' ')
-  }
-  return (
-    Object.entries(v)
-      .filter(([k, vv]) => {
-        if (k === 'default' || k === 'additionalProperties') return false
-        if (k === 'type' && typeof vv === 'string') return false
-        return true
-      })
-      .sort(([a], [b]) => {
-        const scores = [a, b].map(k => (k === 'description' ? 0 : 1))
-        return scores[0] - scores[1]
-      })
-      .map(([k, vv], i) => {
-        if (k === 'description' && i === 0) return String(vv)
-        if (k === 'properties') return `Object (json formatted)`
-        return `${capitaliseFromCamelCase(k)}: ${vv}`
-      })
-      .join('; ') || ''
-  )
-}
-
-function getInnerType(zodType: z.ZodType): z.ZodType {
-  if (zodType instanceof z.ZodOptional) {
-    return getInnerType(zodType._def.innerType)
-  }
-  if (zodType instanceof z.ZodNullable) {
-    return getInnerType(zodType._def.innerType)
-  }
-  if (zodType instanceof z.ZodEffects) {
-    return getInnerType(zodType.innerType())
-  }
-  return zodType
-}
-
-function acceptsStrings(zodType: z.ZodType): boolean {
-  const innerType = getInnerType(zodType)
-  if (innerType instanceof z.ZodString) return true
-  if (innerType instanceof z.ZodEnum) return (innerType.options as unknown[]).some(o => typeof o === 'string')
-  if (innerType instanceof z.ZodLiteral) return typeof innerType.value === 'string'
-  if (innerType instanceof z.ZodUnion) return (innerType.options as z.ZodType[]).some(acceptsStrings)
-  if (innerType instanceof z.ZodIntersection)
-    return acceptsStrings(innerType._def.left) && acceptsStrings(innerType._def.right)
-
-  return false
-}
-
-function acceptsNumbers(zodType: z.ZodType): boolean {
-  const innerType = getInnerType(zodType)
-  if (innerType instanceof z.ZodNumber) return true
-  if (innerType instanceof z.ZodEnum) return (innerType.options as unknown[]).some(o => typeof o === 'number')
-  if (innerType instanceof z.ZodLiteral) return typeof innerType.value === 'number'
-  if (innerType instanceof z.ZodUnion) return (innerType.options as z.ZodType[]).some(acceptsNumbers)
-  if (innerType instanceof z.ZodIntersection)
-    return acceptsNumbers(innerType._def.left) && acceptsNumbers(innerType._def.right)
-
-  return false
-}
-
-function acceptsObject(zodType: z.ZodType): boolean {
-  const innerType = getInnerType(zodType)
-  if (innerType instanceof z.ZodObject) return true
-  if (innerType instanceof z.ZodEffects) return acceptsObject(innerType.innerType())
-  if (innerType instanceof z.ZodUnion) return (innerType.options as z.ZodType[]).some(acceptsObject)
-  if (innerType instanceof z.ZodIntersection)
-    return acceptsObject(innerType._def.left) && acceptsObject(innerType._def.right)
-  return false
-}
-
-type Result<T> = {success: true; value: T} | {success: false; error: string}
-
-export interface ParsedProcedure {
-  /** positional parameters */
-  parameters: string[]
-  /** JSON Schema type describing the flags for the procedure */
-  flagsSchema: JsonSchema7Type
-  /**
-   * Function for taking cleye parsed argv output and transforming it so it can be passed into the procedure
-   * Needed because this function is where inspect the input schema(s) and determine how to map the argv to the input
-   */
-  getInput: (argv: {_: string[]; flags: {}}) => unknown
-}
-
-export function parseProcedureInputs(value: Procedure<any, any>): Result<ParsedProcedure> {
-  if (value._def.inputs.length === 0) {
-    return {
-      success: true,
-      value: {parameters: [], flagsSchema: {}, getInput: () => ({})},
-    }
-  }
-
-  const zodSchema: z.ZodType<any> =
-    value._def.inputs.length === 1
-      ? (value._def.inputs[0] as never)
-      : (z.intersection(...(value._def.inputs as [never, never])) as never)
-
-  if (zodSchema instanceof z.ZodTuple) {
-    const tuple = zodSchema as z.ZodTuple<z.ZodTupleItems>
-    const nonPositionalIndex = tuple.items.findIndex(item => !acceptsStrings(item) && !acceptsNumbers(item))
-    const types = `[${tuple.items.map(s => getInnerType(s).constructor.name).join(', ')}]`
-
-    if (nonPositionalIndex > -1 && nonPositionalIndex !== tuple.items.length - 1) {
-      return {
-        success: false,
-        error: `Invalid input type ${types}. Positional parameters must be strings or numbers.`,
-      }
-    }
-
-    const positionalSchemas = nonPositionalIndex === -1 ? tuple.items : tuple.items.slice(0, nonPositionalIndex)
-
-    const parameterNames = positionalSchemas.map((item, i) => parameterName(item, i + 1))
-    const getParameters = (argv: {_: string[]; flags: {}}) => {
-      return positionalSchemas.map((schema, i) => {
-        if (acceptsNumbers(schema)) return Number(argv._[i])
-        return argv._[i]
-      })
-    }
-
-    if (positionalSchemas.length === tuple.items.length) {
-      // all schemas were positional - no object at the end
-      return {
-        success: true,
-        value: {parameters: parameterNames, flagsSchema: {}, getInput: getParameters},
-      }
-    }
-
-    const last = tuple.items.at(-1)!
-
-    if (!acceptsObject(last)) {
-      return {
-        success: false,
-        error: `Invalid input type ${types}. The last type must accept object inputs.`,
-      }
-    }
-
-    return {
-      success: true,
-      value: {
-        parameters: parameterNames,
-        flagsSchema: zodToJsonSchema(last),
-        getInput: argv => [...getParameters(argv), argv.flags],
-      },
-    }
-  }
-
-  if (!acceptsObject(zodSchema)) {
-    return {
-      success: false,
-      error: `Invalid input type ${getInnerType(zodSchema).constructor.name}, expected object or tuple`,
-    }
-  }
-
-  return {
-    success: true,
-    value: {parameters: [], flagsSchema: zodToJsonSchema(zodSchema), getInput: argv => argv.flags},
-  }
-}
-
-const parameterName = (s: z.ZodType, position: number) => {
-  const name = s.description || `parameter ${position}`
-  return s instanceof z.ZodOptional ? `[${name}]` : `<${name}>`
 }

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -1,0 +1,93 @@
+import type {JsonSchema7ObjectType, JsonSchema7Type} from 'zod-to-json-schema'
+
+const capitaliseFromCamelCase = (camel: string) => {
+  const parts = camel.split(/(?=[A-Z])/)
+  return capitalise(parts.map(p => p.toLowerCase()).join(' '))
+}
+
+const capitalise = (s: string) => s.slice(0, 1).toUpperCase() + s.slice(1)
+
+export const flattenedProperties = (sch: JsonSchema7Type): JsonSchema7ObjectType['properties'] => {
+  if ('properties' in sch) {
+    return sch.properties
+  }
+  if ('allOf' in sch) {
+    return Object.fromEntries(
+      sch.allOf!.flatMap(subSchema => Object.entries(flattenedProperties(subSchema as JsonSchema7Type))),
+    )
+  }
+  if ('anyOf' in sch) {
+    const isExcluded = (v: JsonSchema7Type) => Object.keys(v).join(',') === 'not'
+    const entries = sch.anyOf!.flatMap(subSchema => {
+      const flattened = flattenedProperties(subSchema as JsonSchema7Type)
+      const excluded = Object.entries(flattened).flatMap(([name, propSchema]) => {
+        return isExcluded(propSchema) ? [`--${name}`] : []
+      })
+      return Object.entries(flattened).map(([k, v]): [typeof k, typeof v] => {
+        if (!isExcluded(v) && excluded.length > 0) {
+          return [k, Object.assign({}, v, {'Do not use with': excluded}) as typeof v]
+        }
+        return [k, v]
+      })
+    })
+
+    return Object.fromEntries(
+      entries.sort((a, b) => {
+        const scores = [a, b].map(([_k, v]) => (isExcluded(v) ? 0 : 1)) // Put the excluded ones first, so that `Object.fromEntries` will override them with the non-excluded ones (`Object.fromEntries([['a', 1], ['a', 2]])` => `{a: 2}`)
+        return scores[0] - scores[1]
+      }),
+    )
+  }
+  return {}
+}
+/** For a union type, returns a list of pairs of properties which *shouldn't* be used together (because they don't appear in the same type variant) */
+export const incompatiblePropertyPairs = (sch: JsonSchema7Type): Array<[string, string]> => {
+  const isUnion = 'anyOf' in sch
+  if (!isUnion) return []
+
+  const sets = sch.anyOf!.map(subSchema => {
+    const keys = Object.keys(flattenedProperties(subSchema as JsonSchema7Type))
+    return {keys, set: new Set(keys)}
+  })
+
+  const compatiblityEntries = sets.flatMap(({keys}) => {
+    return keys.map(key => {
+      return [key, new Set(sets.filter(other => other.set.has(key)).flatMap(other => other.keys))] as const
+    })
+  })
+  const allKeys = sets.flatMap(({keys}) => keys)
+
+  return compatiblityEntries.flatMap(([key, compatibleWith]) => {
+    const incompatibleEntries = allKeys
+      .filter(other => key < other && !compatibleWith.has(other))
+      .map((other): [string, string] => [key, other])
+    return incompatibleEntries
+  })
+}
+/**
+ * Tries fairly hard to build a roughly human-readable description of a json-schema type.
+ * A few common properties are given special treatment, most others are just stringified and output in `key: value` format.
+ */
+export const getDescription = (v: JsonSchema7Type): string => {
+  if ('items' in v) {
+    return [getDescription(v.items as JsonSchema7Type), '(array)'].filter(Boolean).join(' ')
+  }
+  return (
+    Object.entries(v)
+      .filter(([k, vv]) => {
+        if (k === 'default' || k === 'additionalProperties') return false
+        if (k === 'type' && typeof vv === 'string') return false
+        return true
+      })
+      .sort(([a], [b]) => {
+        const scores = [a, b].map(k => (k === 'description' ? 0 : 1))
+        return scores[0] - scores[1]
+      })
+      .map(([k, vv], i) => {
+        if (k === 'description' && i === 0) return String(vv)
+        if (k === 'properties') return `Object (json formatted)`
+        return `${capitaliseFromCamelCase(k)}: ${vv}`
+      })
+      .join('; ') || ''
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,38 @@
+import {Router, inferRouterContext} from '@trpc/server'
+import {type JsonSchema7Type} from 'zod-to-json-schema'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TrpcCliParams<R extends Router<any>> = {
+  router: R
+  context?: inferRouterContext<R>
+  alias?: (fullName: string, meta: {command: string; flags: Record<string, unknown>}) => string | undefined
+}
+/**
+ * Optional interface for describing procedures via meta - if your router conforms to this meta shape, it will contribute to the CLI help text.
+ * Based on @see `import('cleye').HelpOptions`
+ */
+
+export interface TrpcCliMeta {
+  /** Version of the script displayed in `--help` output. Use to avoid enabling `--version` flag. */
+  version?: string
+  /** Description of the script or command to display in `--help` output. */
+  description?: string
+  /** Usage code examples to display in `--help` output. */
+  usage?: false | string | string[]
+  /** Example code snippets to display in `--help` output. */
+  examples?: string | string[]
+}
+
+export interface ParsedProcedure {
+  /** positional parameters */
+  parameters: string[]
+  /** JSON Schema type describing the flags for the procedure */
+  flagsSchema: JsonSchema7Type
+  /**
+   * Function for taking cleye parsed argv output and transforming it so it can be passed into the procedure
+   * Needed because this function is where inspect the input schema(s) and determine how to map the argv to the input
+   */
+  getInput: (argv: {_: string[]; flags: {}}) => unknown
+}
+
+export type Result<T> = {success: true; value: T} | {success: false; error: string}

--- a/src/zod-procedure.ts
+++ b/src/zod-procedure.ts
@@ -1,0 +1,129 @@
+import {Procedure} from '@trpc/server'
+import {z} from 'zod'
+import zodToJsonSchema from 'zod-to-json-schema'
+import type {Result, ParsedProcedure} from './types'
+
+function getInnerType(zodType: z.ZodType): z.ZodType {
+  if (zodType instanceof z.ZodOptional) {
+    return getInnerType(zodType._def.innerType as z.ZodType)
+  }
+  if (zodType instanceof z.ZodNullable) {
+    return getInnerType(zodType._def.innerType as z.ZodType)
+  }
+  if (zodType instanceof z.ZodEffects) {
+    return getInnerType(zodType.innerType() as z.ZodType)
+  }
+  return zodType
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseProcedureInputs(value: Procedure<any, any>): Result<ParsedProcedure> {
+  if (value._def.inputs.length === 0) {
+    return {
+      success: true,
+      value: {parameters: [], flagsSchema: {}, getInput: () => ({})},
+    }
+  }
+
+  const zodSchema: z.ZodType =
+    value._def.inputs.length === 1
+      ? (value._def.inputs[0] as never)
+      : (z.intersection(...(value._def.inputs as [never, never])) as never)
+
+  if (zodSchema instanceof z.ZodTuple) {
+    const tuple = zodSchema as z.ZodTuple<[z.ZodType, ...z.ZodType[]]>
+    const nonPositionalIndex = tuple.items.findIndex(item => !acceptsStrings(item) && !acceptsNumbers(item))
+    const types = `[${tuple.items.map(s => getInnerType(s).constructor.name).join(', ')}]`
+
+    if (nonPositionalIndex > -1 && nonPositionalIndex !== tuple.items.length - 1) {
+      return {
+        success: false,
+        error: `Invalid input type ${types}. Positional parameters must be strings or numbers.`,
+      }
+    }
+
+    const positionalSchemas = nonPositionalIndex === -1 ? tuple.items : tuple.items.slice(0, nonPositionalIndex)
+
+    const parameterNames = positionalSchemas.map((item, i) => parameterName(item, i + 1))
+    const getParameters = (argv: {_: string[]; flags: {}}) => {
+      return positionalSchemas.map((schema, i) => {
+        if (acceptsNumbers(schema)) return Number(argv._[i])
+        return argv._[i]
+      })
+    }
+
+    if (positionalSchemas.length === tuple.items.length) {
+      // all schemas were positional - no object at the end
+      return {
+        success: true,
+        value: {parameters: parameterNames, flagsSchema: {}, getInput: getParameters},
+      }
+    }
+
+    const last = tuple.items.at(-1)!
+
+    if (!acceptsObject(last)) {
+      return {
+        success: false,
+        error: `Invalid input type ${types}. The last type must accept object inputs.`,
+      }
+    }
+
+    return {
+      success: true,
+      value: {
+        parameters: parameterNames,
+        flagsSchema: zodToJsonSchema(last),
+        getInput: argv => [...getParameters(argv), argv.flags],
+      },
+    }
+  }
+
+  if (!acceptsObject(zodSchema)) {
+    return {
+      success: false,
+      error: `Invalid input type ${getInnerType(zodSchema).constructor.name}, expected object or tuple`,
+    }
+  }
+
+  return {
+    success: true,
+    value: {parameters: [], flagsSchema: zodToJsonSchema(zodSchema), getInput: argv => argv.flags},
+  }
+}
+const parameterName = (s: z.ZodType, position: number) => {
+  const name = s.description || `parameter ${position}`
+  return s instanceof z.ZodOptional ? `[${name}]` : `<${name}>`
+}
+
+function acceptsStrings(zodType: z.ZodType): boolean {
+  const innerType = getInnerType(zodType)
+  if (innerType instanceof z.ZodString) return true
+  if (innerType instanceof z.ZodEnum) return (innerType.options as unknown[]).some(o => typeof o === 'string')
+  if (innerType instanceof z.ZodLiteral) return typeof innerType.value === 'string'
+  if (innerType instanceof z.ZodUnion) return (innerType.options as z.ZodType[]).some(acceptsStrings)
+  if (innerType instanceof z.ZodIntersection)
+    return acceptsStrings(innerType._def.left as z.ZodType) && acceptsStrings(innerType._def.right as z.ZodType)
+
+  return false
+}
+function acceptsNumbers(zodType: z.ZodType): boolean {
+  const innerType = getInnerType(zodType)
+  if (innerType instanceof z.ZodNumber) return true
+  if (innerType instanceof z.ZodEnum) return (innerType.options as unknown[]).some(o => typeof o === 'number')
+  if (innerType instanceof z.ZodLiteral) return typeof innerType.value === 'number'
+  if (innerType instanceof z.ZodUnion) return (innerType.options as z.ZodType[]).some(acceptsNumbers)
+  if (innerType instanceof z.ZodIntersection)
+    return acceptsNumbers(innerType._def.left as z.ZodType) && acceptsNumbers(innerType._def.right as z.ZodType)
+
+  return false
+}
+function acceptsObject(zodType: z.ZodType): boolean {
+  const innerType = getInnerType(zodType)
+  if (innerType instanceof z.ZodObject) return true
+  if (innerType instanceof z.ZodEffects) return acceptsObject(innerType.innerType() as z.ZodType)
+  if (innerType instanceof z.ZodUnion) return (innerType.options as z.ZodType[]).some(acceptsObject)
+  if (innerType instanceof z.ZodIntersection)
+    return acceptsObject(innerType._def.left as z.ZodType) && acceptsObject(innerType._def.right as z.ZodType)
+  return false
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -37,12 +37,10 @@ test('cli help add', async () => {
     Add two numbers. Use this if you and your friend both have apples, and you want to know how many apples there are in total.
 
     Usage:
-      add [flags...]
+      add [flags...] <parameter 1> <parameter 2>
 
     Flags:
-      -h, --help                  Show help
-          --left <number>         The first number
-          --right <number>        The second number
+      -h, --help        Show help
     "
   `)
 })
@@ -55,12 +53,10 @@ test('cli help divide', async () => {
     Divide two numbers. Useful if you have a number and you want to make it smaller and \`subtract\` isn't quite powerful enough for you.
 
     Usage:
-      divide [flags...]
+      divide [flags...] <numerator> <denominator>
 
     Flags:
-      -h, --help                  Show help
-          --left <number>         The numerator of the division operation.
-          --right <number>        The denominator of the division operation. Note: must not be zero.
+      -h, --help        Show help
 
     Examples:
       divide --left 8 --right 4
@@ -77,18 +73,16 @@ test('cli add failure', async () => {
   const output = await tsx('calculator', ['add', '1', 'notanumber'])
   expect(output).toMatchInlineSnapshot(`
     "Validation error
-      - Expected number, received nan at "--right"
+      - Expected number, received nan at index 1
     add
 
     Add two numbers. Use this if you and your friend both have apples, and you want to know how many apples there are in total.
 
     Usage:
-      add [flags...]
+      add [flags...] <parameter 1> <parameter 2>
 
     Flags:
-      -h, --help                  Show help
-          --left <number>         The first number
-          --right <number>        The second number
+      -h, --help        Show help
     "
   `)
 })
@@ -102,18 +96,16 @@ test('cli divide failure', async () => {
   const output = await tsx('calculator', ['divide', '8', '0'])
   expect(output).toMatchInlineSnapshot(`
     "Validation error
-      - Invalid input at "--right"
+      - Invalid input at index 1
     divide v1.0.0
 
     Divide two numbers. Useful if you have a number and you want to make it smaller and \`subtract\` isn't quite powerful enough for you.
 
     Usage:
-      divide [flags...]
+      divide [flags...] <numerator> <denominator>
 
     Flags:
-      -h, --help                  Show help
-          --left <number>         The numerator of the division operation.
-          --right <number>        The denominator of the division operation. Note: must not be zero.
+      -h, --help        Show help
 
     Examples:
       divide --left 8 --right 4
@@ -258,7 +250,7 @@ test('fs copy help', async () => {
     "copy
 
     Usage:
-      copy [flags...] [Source path] [Destination path]
+      copy [flags...] <Source path> [Destination path]
 
     Flags:
           --force        Overwrite destination if it exists
@@ -282,17 +274,18 @@ test('fs copy', async () => {
   )
 
   // invalid enum value:
-  expect(await tsx('fs', ['copy', 'fileNotFound'])).toMatchInlineSnapshot(`
+  expect(await tsx('fs', ['diff', 'one', 'fileNotFound'])).toMatchInlineSnapshot(`
     "Validation error
-      - Invalid enum value. Expected 'one' | 'two' | 'three' | 'four', received 'fileNotFound' at index 0
-    copy
+      - Invalid enum value. Expected 'one' | 'two' | 'three' | 'four', received 'fileNotFound' at index 1
+    diff
 
     Usage:
-      copy [flags...] [Source path] [Destination path]
+      diff [flags...] <Base path> <Head path>
 
     Flags:
-          --force        Overwrite destination if it exists
-      -h, --help         Show help
+      -h, --help                     Show help
+          --ignore-whitespace        Ignore whitespace changes
+          --trim                     Trim start/end whitespace
     "
   `)
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -69,12 +69,12 @@ test('cli help divide', async () => {
 })
 
 test('cli add', async () => {
-  const output = await tsx('calculator', ['add', '--left', '1', '--right', '2'])
+  const output = await tsx('calculator', ['add', '1', '2'])
   expect(output).toMatchInlineSnapshot(`"3"`)
 })
 
 test('cli add failure', async () => {
-  const output = await tsx('calculator', ['add', '--left', '1', '--right', 'notanumber'])
+  const output = await tsx('calculator', ['add', '1', 'notanumber'])
   expect(output).toMatchInlineSnapshot(`
     "Validation error
       - Expected number, received nan at "--right"
@@ -94,12 +94,12 @@ test('cli add failure', async () => {
 })
 
 test('cli divide', async () => {
-  const output = await tsx('calculator', ['divide', '--left', '8', '--right', '4'])
+  const output = await tsx('calculator', ['divide', '8', '4'])
   expect(output).toMatchInlineSnapshot(`"2"`)
 })
 
 test('cli divide failure', async () => {
-  const output = await tsx('calculator', ['divide', '--left', '8', '--right', '0'])
+  const output = await tsx('calculator', ['divide', '8', '0'])
   expect(output).toMatchInlineSnapshot(`
     "Validation error
       - Invalid input at "--right"

--- a/test/fixtures/calculator.ts
+++ b/test/fixtures/calculator.ts
@@ -1,6 +1,6 @@
 import * as trpcServer from '@trpc/server'
 import {z} from 'zod'
-import {TrpcCliMeta, trpcCli} from '../../src'
+import {trpcCli, type TrpcCliMeta} from '../../src'
 
 const trpc = trpcServer.initTRPC.meta<TrpcCliMeta>().create()
 

--- a/test/fixtures/calculator.ts
+++ b/test/fixtures/calculator.ts
@@ -10,36 +10,21 @@ const router = trpc.router({
       description:
         'Add two numbers. Use this if you and your friend both have apples, and you want to know how many apples there are in total.',
     })
-    .input(
-      z.object({
-        left: z.number().describe('The first number'),
-        right: z.number().describe('The second number'),
-      }),
-    )
-    .query(({input}) => input.left + input.right),
+    .input(z.tuple([z.number(), z.number()]))
+    .query(({input}) => input[0] + input[1]),
   subtract: trpc.procedure
     .meta({
       description: 'Subtract two numbers. Useful if you have a number and you want to make it smaller.',
     })
-    .input(
-      z.object({
-        left: z.number().describe('The first number'),
-        right: z.number().describe('The second number'),
-      }),
-    )
-    .query(({input}) => input.left - input.right),
+    .input(z.tuple([z.number(), z.number()]))
+    .query(({input}) => input[0] - input[1]),
   multiply: trpc.procedure
     .meta({
       description:
         'Multiply two numbers together. Useful if you want to count the number of tiles on your bathroom wall and are short on time.',
     })
-    .input(
-      z.object({
-        left: z.number().describe('The first number'),
-        right: z.number().describe('The second number'),
-      }),
-    )
-    .query(({input}) => input.left * input.right),
+    .input(z.tuple([z.number(), z.number()]))
+    .query(({input}) => input[0] * input[1]),
   divide: trpc.procedure
     .meta({
       version: '1.0.0',
@@ -48,15 +33,15 @@ const router = trpc.router({
       examples: 'divide --left 8 --right 4',
     })
     .input(
-      z.object({
-        left: z.number().describe('The numerator of the division operation.'),
-        right: z
+      z.tuple([
+        z.number().describe('numerator'),
+        z
           .number()
           .refine(n => n !== 0)
-          .describe('The denominator of the division operation. Note: must not be zero.'),
-      }),
+          .describe('denominator'),
+      ]),
     )
-    .mutation(({input}) => input.left / input.right),
+    .mutation(({input}) => input[0] / input[1]),
 })
 
 void trpcCli({router}).run()

--- a/test/fixtures/fs.ts
+++ b/test/fixtures/fs.ts
@@ -1,6 +1,6 @@
 import * as trpcServer from '@trpc/server'
 import {z} from 'zod'
-import {TrpcCliMeta, trpcCli} from '../../src'
+import {trpcCli, type TrpcCliMeta} from '../../src'
 
 const trpc = trpcServer.initTRPC.meta<TrpcCliMeta>().create()
 

--- a/test/fixtures/fs.ts
+++ b/test/fixtures/fs.ts
@@ -1,0 +1,59 @@
+import * as trpcServer from '@trpc/server'
+import {z} from 'zod'
+import {TrpcCliMeta, trpcCli} from '../../src'
+
+const trpc = trpcServer.initTRPC.meta<TrpcCliMeta>().create()
+
+const fakeFileSystem = getFakeFileSystem()
+
+const router = trpc.router({
+  copy: trpc.procedure
+    .input(
+      z.tuple([
+        z.string().describe('Source path'), //
+        z.string().nullish().describe('Destination path'),
+        z.object({
+          force: z.boolean().optional().default(false).describe('Overwrite destination if it exists'),
+        }),
+      ]),
+    )
+    .mutation(async ({input: [source, destination = `${source}.copy`, options]}) => {
+      // ...copy logic...
+      return {source, destination, options}
+    }),
+  diff: trpc.procedure
+    .input(
+      z.tuple([
+        z.enum(['one', 'two', 'three', 'four']).describe('Base path'),
+        z.enum(['one', 'two', 'three', 'four']).describe('Head path'),
+        z.object({
+          ignoreWhitespace: z.boolean().optional().default(false).describe('Ignore whitespace changes'),
+          trim: z.boolean().optional().default(false).describe('Trim start/end whitespace'),
+        }),
+      ]),
+    )
+    .query(async ({input: [base, head, options]}) => {
+      const [left, right] = [base, head].map(path => {
+        let content = fakeFileSystem[path]
+        if (options?.trim) content = content.trim()
+        if (options?.ignoreWhitespace) content = content.replaceAll(/\s/g, '')
+        return content
+      })
+
+      if (left === right) return null
+      if (left.length !== right.length) return `base has length ${left.length} and head has length ${right.length}`
+      const firstDiffIndex = left.split('').findIndex((char, i) => char !== right[i])
+      return `base and head differ at index ${firstDiffIndex} (${JSON.stringify(left[firstDiffIndex])} !== ${JSON.stringify(right[firstDiffIndex])})`
+    }),
+})
+
+function getFakeFileSystem(): Record<string, string> {
+  return {
+    one: 'a,b,c',
+    two: 'a,b,c',
+    three: 'x,y,z',
+    four: 'x,y,z ',
+  }
+}
+
+void trpcCli({router}).run()

--- a/test/fixtures/migrations.ts
+++ b/test/fixtures/migrations.ts
@@ -50,7 +50,7 @@ const router = trpc.router({
   create: trpc.procedure
     .meta({description: 'Create a new migration'})
     .input(
-      z.object({name: z.string(), content: z.string()}), //
+      z.object({name: z.string(), content: z.string(), bb: z.boolean()}), //
     )
     .mutation(async ({input}) => {
       migrations.push({...input, status: 'pending'})

--- a/test/fixtures/migrations.ts
+++ b/test/fixtures/migrations.ts
@@ -1,6 +1,6 @@
 import * as trpcServer from '@trpc/server'
 import {z} from 'zod'
-import {TrpcCliMeta, trpcCli} from '../../src'
+import {trpcCli, type TrpcCliMeta} from '../../src'
 
 const trpc = trpcServer.initTRPC.meta<TrpcCliMeta>().create()
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,0 +1,36 @@
+import {initTRPC} from '@trpc/server'
+import {test, expect} from 'vitest'
+import {z} from 'zod'
+import {TrpcCliMeta, trpcCli} from '../src'
+
+const t = initTRPC.meta<TrpcCliMeta>().create()
+
+test('validation', async () => {
+  const router = t.router({
+    okTuple: t.procedure
+      .input(z.tuple([z.string().describe('The first string'), z.string().describe('The second string')]))
+      .query(() => 'ok'),
+    tupleWithNumber: t.procedure
+      .input(z.tuple([z.string(), z.number()])) //
+      .query(() => 'ok'),
+    tupleWithNumberThenObject: t.procedure
+      .input(z.tuple([z.string(), z.number(), z.object({foo: z.string()})]))
+      .query(() => 'ok'),
+    tupleWithObjectInTheMiddle: t.procedure
+      .input(z.tuple([z.string(), z.object({foo: z.string()}), z.string()]))
+      .query(() => 'ok'),
+    tupleWithRecord: t.procedure
+      .input(z.tuple([z.string(), z.record(z.string())])) //
+      .query(() => 'ok'),
+  })
+  const cli = trpcCli({router})
+
+  expect(cli.ignoredProcedures).toMatchInlineSnapshot(`
+    {
+      "tupleWithNumber": "Invalid input type [ZodString, ZodNumber]. Type following positionals must accept object inputs.",
+      "tupleWithNumberThenObject": "Invalid input type [ZodString, ZodNumber, ZodObject]. Positional parameters must be strings.",
+      "tupleWithObjectInTheMiddle": "Invalid input type [ZodString, ZodObject, ZodString]. Positional parameters must be strings.",
+      "tupleWithRecord": "Invalid input type [ZodString, ZodRecord]. Type following positionals must accept object inputs.",
+    }
+  `)
+})

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -7,14 +7,14 @@ const t = initTRPC.meta<TrpcCliMeta>().create()
 
 test('validation', async () => {
   const router = t.router({
-    okTuple: t.procedure
+    tupleOfStrings: t.procedure
       .input(z.tuple([z.string().describe('The first string'), z.string().describe('The second string')]))
       .query(() => 'ok'),
-    tupleWithNumber: t.procedure
-      .input(z.tuple([z.string(), z.number()])) //
+    tupleWithBoolean: t.procedure
+      .input(z.tuple([z.string(), z.boolean()])) //
       .query(() => 'ok'),
-    tupleWithNumberThenObject: t.procedure
-      .input(z.tuple([z.string(), z.number(), z.object({foo: z.string()})]))
+    tupleWithBooleanThenObject: t.procedure
+      .input(z.tuple([z.string(), z.boolean(), z.object({foo: z.string()})]))
       .query(() => 'ok'),
     tupleWithObjectInTheMiddle: t.procedure
       .input(z.tuple([z.string(), z.object({foo: z.string()}), z.string()]))
@@ -27,10 +27,10 @@ test('validation', async () => {
 
   expect(cli.ignoredProcedures).toMatchInlineSnapshot(`
     {
-      "tupleWithNumber": "Invalid input type [ZodString, ZodNumber]. Type following positionals must accept object inputs.",
-      "tupleWithNumberThenObject": "Invalid input type [ZodString, ZodNumber, ZodObject]. Positional parameters must be strings.",
-      "tupleWithObjectInTheMiddle": "Invalid input type [ZodString, ZodObject, ZodString]. Positional parameters must be strings.",
-      "tupleWithRecord": "Invalid input type [ZodString, ZodRecord]. Type following positionals must accept object inputs.",
+      "tupleWithBoolean": "Invalid input type [ZodString, ZodBoolean]. The last type must accept object inputs.",
+      "tupleWithBooleanThenObject": "Invalid input type [ZodString, ZodBoolean, ZodObject]. Positional parameters must be strings or numbers.",
+      "tupleWithObjectInTheMiddle": "Invalid input type [ZodString, ZodObject, ZodString]. Positional parameters must be strings or numbers.",
+      "tupleWithRecord": "Invalid input type [ZodString, ZodRecord]. The last type must accept object inputs.",
     }
   `)
 })

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,7 +1,8 @@
 import {initTRPC} from '@trpc/server'
 import {test, expect} from 'vitest'
 import {z} from 'zod'
-import {TrpcCliMeta, trpcCli} from '../src'
+import {trpcCli} from '../src'
+import {TrpcCliMeta} from '../src/types'
 
 const t = initTRPC.meta<TrpcCliMeta>().create()
 


### PR DESCRIPTION
- Support positional parameters like `migra postgresql://a psotgresql://b`
- Also support numbers
- `getInnerType` helper to more accurately inspect zod schemas
- reorganise src dir into separate files rather than one 400+ line index.ts
- udpate calculator example to use positional parameters so `calculator add 2 3` rather than `calculator add --left 2 --right 3`
- more hand-written docs on how flags and positional parameters work
- return `ignoredProcedures` instead of throwing when invalid
- add a validation test