### PR TITLE
Line-by-line logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,11 @@ If the procedure returns `[{name: 'one'}, {name: 'two'}, {name: 'three'}]` this 
 }
 ```
 
-The process will exit with code 0 if the command was successful, or 1 otherwise. If you don't want to rely on this logging, you can always log inside your procedures and avoid returning a value. You can also override the `logger` and `process` properties of the `run` method:
+This is to make it as easy as possible to use with other command line tools like `xargs`, `jq` etc. via bash-piping. If you don't want to rely on this logging, you can always log inside your procedures however you like and avoid returning a value.
+
+The process will exit with code 0 if the command was successful, or 1 otherwise. 
+
+You can also override the `logger` and `process` properties of the `run` method to change the default return-value logging and/or process.exit behaviour:
 
 <!-- eslint-disable unicorn/no-process-exit -->
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ import {ZodError} from 'zod'
 import {type JsonSchema7Type} from 'zod-to-json-schema'
 import * as zodValidationError from 'zod-validation-error'
 import {flattenedProperties, incompatiblePropertyPairs, getDescription} from './json-schema'
-import {TrpcCliParams} from './types'
+import {primitiveOrJsonConsoleLogger} from './logging'
+import {Logger, TrpcCliParams} from './types'
 import {parseProcedureInputs} from './zod-procedure'
 
 export * from './types'
@@ -50,12 +51,8 @@ export const trpcCli = <R extends AnyRouter>({router, ...params}: TrpcCliParams<
     procedures.flatMap(([k, v]) => (typeof v === 'string' ? [[k, v] as const] : [])),
   )
 
-  async function run(runParams?: {
-    argv?: string[]
-    logger?: {info?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void}
-    process?: {exit: (code: number) => never}
-  }) {
-    const logger = {...console, ...runParams?.logger}
+  async function run(runParams?: {argv?: string[]; logger?: Logger; process?: {exit: (code: number) => never}}) {
+    const logger = {...primitiveOrJsonConsoleLogger, ...runParams?.logger}
     const _process = runParams?.process || process
     let verboseErrors: boolean = false
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {ZodError} from 'zod'
 import {type JsonSchema7Type} from 'zod-to-json-schema'
 import * as zodValidationError from 'zod-validation-error'
 import {flattenedProperties, incompatiblePropertyPairs, getDescription} from './json-schema'
-import {primitiveOrJsonConsoleLogger} from './logging'
+import {lineByLineConsoleLogger} from './logging'
 import {Logger, TrpcCliParams} from './types'
 import {parseProcedureInputs} from './zod-procedure'
 
@@ -52,7 +52,7 @@ export const trpcCli = <R extends AnyRouter>({router, ...params}: TrpcCliParams<
   )
 
   async function run(runParams?: {argv?: string[]; logger?: Logger; process?: {exit: (code: number) => never}}) {
-    const logger = {...primitiveOrJsonConsoleLogger, ...runParams?.logger}
+    const logger = {...lineByLineConsoleLogger, ...runParams?.logger}
     const _process = runParams?.process || process
     let verboseErrors: boolean = false
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,4 +1,4 @@
-import {LogMethod as LogFn, Logger} from './types'
+import {Log, Logger} from './types'
 
 export const lineByLineLogger = getLoggerTransformer(log => {
   /**
@@ -25,10 +25,8 @@ const isPrimitive = (value: unknown): value is string | number | boolean => {
   return type === 'string' || type === 'number' || type === 'boolean'
 }
 
-type TransformLogMethod = (log: LogFn) => LogFn
-
 /** Takes a function that wraps an individual log function, and returns a function that wraps the `info` and `error` functions for a logger */
-function getLoggerTransformer(transform: TransformLogMethod) {
+function getLoggerTransformer(transform: (log: Log) => Log) {
   return (logger: Logger): Logger => {
     const info = logger.info && transform(logger.info)
     const error = logger.error && transform(logger.error)

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,15 +1,15 @@
 import {LogMethod, Logger} from './types'
 
-export const primitiveOrJsonLogger = getLoggerTransformer(method => {
+export const primitiveOrJsonLogger = getLoggerTransformer(log => {
   const transformed: LogMethod = (...args) => {
     if (args.length === 1 && Array.isArray(args[0])) {
       args[0].forEach(item => transformed(item))
     } else if (args.every(isPrimitive)) {
-      method(...args)
+      log(...args)
     } else if (args.length === 1) {
-      method(JSON.stringify(args[0], null, 2))
+      log(JSON.stringify(args[0], null, 2))
     } else {
-      method(JSON.stringify(args, null, 2))
+      log(JSON.stringify(args, null, 2))
     }
   }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,34 @@
+import {LogMethod, Logger} from './types'
+
+export const primitiveOrJsonLogger = getLoggerTransformer(method => {
+  const transformed: LogMethod = (...args) => {
+    if (args.length === 1 && Array.isArray(args[0])) {
+      args[0].forEach(item => transformed(item))
+    } else if (args.every(isPrimitive)) {
+      method(...args)
+    } else if (args.length === 1) {
+      method(JSON.stringify(args[0], null, 2))
+    } else {
+      method(JSON.stringify(args, null, 2))
+    }
+  }
+
+  return transformed
+})
+
+const isPrimitive = (value: unknown): value is string | number | boolean => {
+  const type = typeof value
+  return type === 'string' || type === 'number' || type === 'boolean'
+}
+
+type TransformLogMethod = (method: LogMethod) => LogMethod
+
+function getLoggerTransformer(transform: TransformLogMethod) {
+  return (logger: Logger): Logger => {
+    const info = logger.info && transform(logger.info)
+    const error = logger.error && transform(logger.error)
+    return {info, error}
+  }
+}
+
+export const primitiveOrJsonConsoleLogger = primitiveOrJsonLogger(console)

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,14 +48,19 @@ export interface ParsedProcedure {
    * Function for taking cleye parsed argv output and transforming it so it can be passed into the procedure
    * Needed because this function is where inspect the input schema(s) and determine how to map the argv to the input
    */
-  getInput: (argv: {_: string[]; flags: {}}) => unknown
+  getInput: (argv: {_: string[]; flags: Record<string, unknown>}) => unknown
 }
 
 export type Result<T> = {success: true; value: T} | {success: false; error: string}
 
-export type LogMethod = (...args: unknown[]) => void
+/** A function that logs any inputs. e.g. `console.info` */
+export type Log = (...args: unknown[]) => void
 
+/**
+ * A struct which has `info` and `error` functions for logging. Easiest example: `console`
+ * But most loggers like pino, winston etc. have a similar interface.
+ */
 export interface Logger {
-  info?: LogMethod
-  error?: LogMethod
+  info?: Log
+  error?: Log
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,3 +52,10 @@ export interface ParsedProcedure {
 }
 
 export type Result<T> = {success: true; value: T} | {success: false; error: string}
+
+export type LogMethod = (...args: unknown[]) => void
+
+export interface Logger {
+  info?: LogMethod
+  error?: LogMethod
+}

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -134,25 +134,21 @@ test('migrations union type', async () => {
   let output = await tsx('migrations', ['apply', '--to', 'four'])
 
   expect(output).toMatchInlineSnapshot(`
-    "[
-      'one: executed',
-      'two: executed',
-      'three: executed',
-      'four: executed',
-      'five: pending'
-    ]"
+    "one: executed
+    two: executed
+    three: executed
+    four: executed
+    five: pending"
   `)
 
   output = await tsx('migrations', ['apply', '--step', '1'])
   expect(output).toContain('four: pending') // <-- this sometimes goes wrong when I mess with union type handling
   expect(output).toMatchInlineSnapshot(`
-    "[
-      'one: executed',
-      'two: executed',
-      'three: executed',
-      'four: pending',
-      'five: pending'
-    ]"
+    "one: executed
+    two: executed
+    three: executed
+    four: pending
+    five: pending"
   `)
 })
 
@@ -177,36 +173,32 @@ test('migrations search.byName help', async () => {
 test('migrations search.byName', async () => {
   const output = await tsx('migrations', ['search.byName', '--name', 'two'])
   expect(output).toMatchInlineSnapshot(`
-    "[
-      {
-        name: 'two',
-        content: 'create view two as select name from one',
-        status: 'executed'
-      }
-    ]"
+    "{
+      "name": "two",
+      "content": "create view two as select name from one",
+      "status": "executed"
+    }"
   `)
 })
 
 test('migrations search.byContent', async () => {
   const output = await tsx('migrations', ['search.byContent', '--searchTerm', 'create table'])
   expect(output).toMatchInlineSnapshot(`
-    "[
-      {
-        name: 'one',
-        content: 'create table one(id int, name text)',
-        status: 'executed'
-      },
-      {
-        name: 'three',
-        content: 'create table three(id int, foo int)',
-        status: 'pending'
-      },
-      {
-        name: 'five',
-        content: 'create table five(id int)',
-        status: 'pending'
-      }
-    ]"
+    "{
+      "name": "one",
+      "content": "create table one(id int, name text)",
+      "status": "executed"
+    }
+    {
+      "name": "three",
+      "content": "create table three(id int, foo int)",
+      "status": "pending"
+    }
+    {
+      "name": "five",
+      "content": "create table five(id int)",
+      "status": "pending"
+    }"
   `)
 })
 
@@ -261,16 +253,48 @@ test('fs copy help', async () => {
 
 test('fs copy', async () => {
   expect(await tsx('fs', ['copy', 'one'])).toMatchInlineSnapshot(
-    `"{ source: 'one', destination: 'one.copy', options: { force: false } }"`,
+    `
+      "{
+        "source": "one",
+        "destination": "one.copy",
+        "options": {
+          "force": false
+        }
+      }"
+    `,
   )
   expect(await tsx('fs', ['copy', 'one', 'uno'])).toMatchInlineSnapshot(
-    `"{ source: 'one', destination: 'uno', options: { force: false } }"`,
+    `
+      "{
+        "source": "one",
+        "destination": "uno",
+        "options": {
+          "force": false
+        }
+      }"
+    `,
   )
   expect(await tsx('fs', ['copy', 'one', '--force'])).toMatchInlineSnapshot(
-    `"{ source: 'one', destination: 'one.copy', options: { force: true } }"`,
+    `
+      "{
+        "source": "one",
+        "destination": "one.copy",
+        "options": {
+          "force": true
+        }
+      }"
+    `,
   )
   expect(await tsx('fs', ['copy', 'one', 'uno', '--force'])).toMatchInlineSnapshot(
-    `"{ source: 'one', destination: 'uno', options: { force: true } }"`,
+    `
+      "{
+        "source": "one",
+        "destination": "uno",
+        "options": {
+          "force": true
+        }
+      }"
+    `,
   )
 
   // invalid enum value:

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -2,6 +2,7 @@ import {execa} from 'execa'
 import * as path from 'path'
 import stripAnsi from 'strip-ansi'
 import {expect, test} from 'vitest'
+import '../src' // make sure vitest reruns this file after every change
 
 const tsx = async (file: string, args: string[]) => {
   const {all} = await execa('./node_modules/.bin/tsx', ['test/fixtures/' + file, ...args], {

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -1,10 +1,10 @@
 import {beforeEach, expect, test, vi} from 'vitest'
-import {primitiveOrJsonLogger} from '../src/logging'
+import {lineByLineLogger} from '../src/logging'
 
 const info = vi.fn()
 const error = vi.fn()
 const mocks = {info, error}
-const jsonish = primitiveOrJsonLogger(mocks)
+const jsonish = lineByLineLogger(mocks)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -40,6 +40,24 @@ test('primitives array', async () => {
     11
     true
     m3
+  `)
+})
+
+test('array array', async () => {
+  jsonish.info!([
+    ['m1', 'm2'],
+    ['m3', 'm4'],
+  ])
+
+  expect(info).toMatchInlineSnapshot(`
+    [
+      "m1",
+      "m2"
+    ]
+    [
+      "m3",
+      "m4"
+    ]
   `)
 })
 

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -1,0 +1,70 @@
+import {beforeEach, expect, test, vi} from 'vitest'
+import {primitiveOrJsonLogger} from '../src/logging'
+
+const info = vi.fn()
+const error = vi.fn()
+const mocks = {info, error}
+const jsonish = primitiveOrJsonLogger(mocks)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+expect.addSnapshotSerializer({
+  test: val => val.mock.calls,
+  print: (val: any) => val.mock.calls.map((call: unknown[]) => call.join(' ')).join('\n'),
+})
+
+test('logging', async () => {
+  jsonish.info!('Hello', 'world')
+
+  expect(info).toMatchInlineSnapshot(`Hello world`)
+})
+
+test('string array', async () => {
+  jsonish.info!(['m1', 'm2', 'm3'])
+
+  expect(info).toMatchInlineSnapshot(`
+    m1
+    m2
+    m3
+  `)
+})
+
+test('primitives array', async () => {
+  jsonish.info!(['m1', 'm2', 11, true, 'm3'])
+
+  expect(info).toMatchInlineSnapshot(`
+    m1
+    m2
+    11
+    true
+    m3
+  `)
+})
+
+test('multi primitives', async () => {
+  jsonish.info!('m1', 11, true, 'm2')
+  jsonish.info!('m1', 12, false, 'm2')
+
+  expect(info).toMatchInlineSnapshot(`
+    m1 11 true m2
+    m1 12 false m2
+  `)
+})
+
+test('object array', async () => {
+  jsonish.info!([{name: 'm1'}, {name: 'm2'}, {name: 'm3'}])
+
+  expect(info).toMatchInlineSnapshot(`
+    {
+      "name": "m1"
+    }
+    {
+      "name": "m2"
+    }
+    {
+      "name": "m3"
+    }
+  `)
+})


### PR DESCRIPTION
Updated default logger. 

Docs (from new readme):

- Arrays will be logged line be line
- For each line logged:
   - string, numbers and booleans are logged directly
   - objects are logged with `JSON.stringify(___, null, 2)`

So if the procedure returns `['one', 'two', 'three]` this will be written to stdout:

```
one
two
three
```

If the procedure returns `[{name: 'one'}, {name: 'two'}, {name: 'three'}]` this will be written to stdout:

```
{
  "name": "one"
}
{
  "name": "two"
}
{
  "name": "three"
}
```

This is to make it as easy as possible to use with other command line tools like `xargs`, `jq` etc. via bash-piping. If you don't want to rely on this logging, you can always log inside your procedures however you like and avoid returning a value.