### PR TITLE
Fix looksLikeInstanceof(null)

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const looksLikeInstanceof = <T>(value: unknown, target: new (...args: any[]) => T): value is T => {
   let current = value?.constructor
-  while (current?.name){
+  while (current?.name) {
     if (current?.name === target.name) return true
     current = Object.getPrototypeOf(current) as Function
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,9 +9,9 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const looksLikeInstanceof = <T>(value: unknown, target: new (...args: any[]) => T): value is T => {
   let current = value?.constructor
-  do {
+  while (current?.name){
     if (current?.name === target.name) return true
     current = Object.getPrototypeOf(current) as Function
-  } while (current?.name)
+  }
   return false
 }


### PR DESCRIPTION
I was getting this error after updating to 0.5.0, which goes away with the proposed fix
```ts
13 | const looksLikeInstanceof = (value, target) => {
14 |     let current = value?.constructor;
15 |     do {
16 |         if (current?.name === target.name)
17 |             return true;
18 |         current = Object.getPrototypeOf(current);
                              ^
TypeError: undefined is not an object (evaluating 'Object.getPrototypeOf(current)')
```