### PR TITLE
standard-schema error

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ You can also explicitly opt into this behavior for any procedure by setting `jso
 ### API docs
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/index.ts, export: createCli} -->
-#### [createCli](./src/index.ts#L125)
+#### [createCli](./src/index.ts#L128)
 
 Run a trpc router as a CLI.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,10 @@ import {
 import {lineByLineConsoleLogger} from './logging'
 import {parseProcedureInputs} from './parse-procedure'
 import {promptify} from './prompts'
+import {prettifyStandardSchemaError} from './standard-schema/errors'
+import {looksLikeStandardSchemaFailure} from './standard-schema/utils'
 import {AnyProcedure, AnyRouter, CreateCallerFactoryLike, isTrpc11Procedure} from './trpc-compat'
-import {Dependencies, TrpcCli, TrpcCliMeta, TrpcCliParams, TrpcCliRunParams} from './types'
+import {TrpcCli, TrpcCliMeta, TrpcCliParams, TrpcCliRunParams} from './types'
 import {looksLikeInstanceof} from './util'
 
 export * from './types'
@@ -124,7 +126,6 @@ export const parseRouter = <R extends AnyRouter>({router, ...params}: TrpcCliPar
  */
 export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParams<R>): TrpcCli {
   const procedureEntries = parseRouter({router, ...params})
-  const procedureEntriesMap = new Map(procedureEntries)
 
   function buildProgram(runParams?: TrpcCliRunParams) {
     const logger = {...lineByLineConsoleLogger, ...runParams?.logger}
@@ -414,8 +415,7 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
         const caller = createCallerFactory(router)(params.context)
 
         const result = await (caller[procedurePath](input) as Promise<unknown>).catch(err => {
-          const procedure = procedureEntriesMap.get(procedurePath)
-          throw transformError(err, command, procedure?.procedure?._def.inputs || [], params)
+          throw transformError(err, command)
         })
         command.__result = result
         if (result != null) logger.info?.(result)
@@ -573,9 +573,7 @@ function kebabCase(propName: string) {
 /** @deprecated renamed to `createCli` */
 export const trpcCli = createCli
 
-function transformError(err: unknown, command: Command, procedureInputs: unknown[], dependencies: Dependencies) {
-  type Zod4Error = never // this will import from zod/v4 in future
-  const zod4PrettifyError = dependencies?.zod?.prettifyError
+function transformError(err: unknown, command: Command) {
   if (looksLikeInstanceof(err, Error) && err.message.includes('This is a client-only function')) {
     return new Error(
       'Failed to create trpc caller. If using trpc v10, either upgrade to v11 or pass in the `@trpc/server` module to `createCli` explicitly',
@@ -584,13 +582,8 @@ function transformError(err: unknown, command: Command, procedureInputs: unknown
 
   if (looksLikeInstanceof<trpcServer11.TRPCError>(err, 'TRPCError')) {
     const cause = err.cause
-    const isZod4Input =
-      !!zod4PrettifyError &&
-      procedureInputs.length > 0 &&
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      procedureInputs.every(input => (input as any)._zod?.version?.major == 4)
-    if (err.code === 'BAD_REQUEST' && isZod4Input && looksLikeInstanceof<Zod4Error>(cause, 'ZodError')) {
-      const prettyMessage = zod4PrettifyError(cause)
+    if (looksLikeStandardSchemaFailure(cause)) {
+      const prettyMessage = prettifyStandardSchemaError(cause)
       return new CliValidationError(prettyMessage + '\n\n' + command.helpInformation())
     }
 

--- a/src/standard-schema/contract.ts
+++ b/src/standard-schema/contract.ts
@@ -1,4 +1,4 @@
-// copied from https://github.com/standard-schema/standard-schema/tree/main/README.md
+// from https://github.com/standard-schema/standard-schema
 
 /** The Standard Schema interface. */
 export interface StandardSchemaV1<Input = unknown, Output = Input> {

--- a/src/standard-schema/errors.ts
+++ b/src/standard-schema/errors.ts
@@ -1,0 +1,56 @@
+import {StandardSchemaV1} from './contract'
+import {looksLikeStandardSchemaFailure} from './utils'
+
+export const prettifyStandardSchemaError = (error: unknown): string | null => {
+  if (!looksLikeStandardSchemaFailure(error)) return null
+
+  const issues = [...error.issues]
+    .map(issue => {
+      const path = issue.path || []
+      const primitivePathSegments = path.map(segment => {
+        if (typeof segment === 'string' || typeof segment === 'number' || typeof segment === 'symbol') return segment
+        return segment.key
+      })
+      const dotPath = toDotPath(primitivePathSegments)
+      return {
+        issue,
+        path,
+        primitivePathSegments,
+        dotPath,
+      }
+    })
+    .sort((a, b) => a.path.length - b.path.length)
+
+  const lines: string[] = []
+
+  for (const {issue, dotPath} of issues) {
+    let message = `✖ ${issue.message}`
+    if (dotPath) message += ` → at ${dotPath}`
+    lines.push(message)
+  }
+
+  return lines.join('\n')
+}
+
+export function toDotPath(path: (string | number | symbol)[]): string {
+  const segs: string[] = []
+  for (const seg of path) {
+    if (typeof seg === 'number') segs.push(`[${seg}]`)
+    else if (typeof seg === 'symbol') segs.push(`[${JSON.stringify(String(seg))}]`)
+    else if (/[^\w$]/.test(seg)) segs.push(`[${JSON.stringify(seg)}]`)
+    else {
+      if (segs.length) segs.push('.')
+      segs.push(seg)
+    }
+  }
+
+  return segs.join('')
+}
+
+export class StandardSchemaV1Error extends Error implements StandardSchemaV1.FailureResult {
+  issues: StandardSchemaV1.FailureResult['issues']
+  constructor(failure: StandardSchemaV1.FailureResult, options?: {cause?: Error}) {
+    super('Standard Schema error - details in `issues`.', options)
+    this.issues = failure.issues
+  }
+}

--- a/src/standard-schema/utils.ts
+++ b/src/standard-schema/utils.ts
@@ -1,0 +1,9 @@
+import {StandardSchemaV1} from './contract'
+
+export const looksLikeStandardSchemaFailure = (error: unknown): error is StandardSchemaV1.FailureResult => {
+  return !!error && typeof error === 'object' && 'issues' in error && Array.isArray(error.issues)
+}
+
+export const looksLikeStandardSchema = (thing: unknown): thing is StandardSchemaV1 => {
+  return !!thing && typeof thing === 'object' && '~standard' in thing && typeof thing['~standard'] === 'object'
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,8 +7,6 @@
  * So, only use it for classes that are unlikely to have name conflicts like `ZodAbc` or `TRPCDef`.
  */
 
-import {StandardSchemaV1} from './standard-schema'
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const looksLikeInstanceof = <T>(value: unknown, target: string | (new (...args: any[]) => T)): value is T => {
   let current = value?.constructor
@@ -17,16 +15,4 @@ export const looksLikeInstanceof = <T>(value: unknown, target: string | (new (..
     current = Object.getPrototypeOf(current) as typeof current // parent class
   }
   return false
-}
-
-export const looksLikeStandardSchemaFailureResult = (value: unknown): value is StandardSchemaV1.FailureResult => {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'issues' in value &&
-    Array.isArray(value.issues) &&
-    value.issues.every(
-      issue => typeof issue === 'object' && issue !== null && 'message' in issue && typeof issue.message === 'string',
-    )
-  )
 }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -168,8 +168,7 @@ test('cli divide', async () => {
 test('cli divide failure', async () => {
   const output = await tsx('calculator', ['divide', '8', '0'])
   expect(output).toMatchInlineSnapshot(`
-    "Validation error
-      - Invalid input at index 1
+    "✖ Invalid input → at [1]
 
     Usage: calculator divide [options] <numerator> <denominator>
 
@@ -442,8 +441,7 @@ test('fs copy', async () => {
 
   // invalid enum value:
   expect(await tsx('fs', ['diff', 'one', 'fileNotFound'])).toMatchInlineSnapshot(`
-    "Validation error
-      - Invalid enum value. Expected 'one' | 'two' | 'three' | 'four', received 'fileNotFound' at index 1
+    "✖ Invalid enum value. Expected 'one' | 'two' | 'three' | 'four', received 'fileNotFound' → at [1]
 
     Usage: fs diff [options] <Base path> <Head path>
 

--- a/test/effect.test.ts
+++ b/test/effect.test.ts
@@ -40,7 +40,8 @@ test('enum input', async () => {
   expect(await run(router, ['foo', 'aa'])).toMatchInlineSnapshot(`""aa""`)
   await expect(run(router, ['foo', 'cc'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Expected "aa", actual "cc"
+      Caused by: CliValidationError: ✖ Expected "aa", actual "cc"
+    ✖ Expected "bb", actual "cc"
   `)
 })
 

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -52,8 +52,7 @@ test('override of process.exit and pass in bad option', async () => {
   )
   expect(result.exitCode).toBe(1)
   expect(result.cause).toMatchInlineSnapshot(`
-    [Error: Validation error
-      - Expected number, received string at "bar"
+    [Error: ✖ Expected number, received string → at bar
 
     Usage: program foo [options]
 

--- a/test/valibot.test.ts
+++ b/test/valibot.test.ts
@@ -75,7 +75,7 @@ test('enum input', async () => {
   expect(await run(router, ['foo', 'aa'])).toMatchInlineSnapshot(`""aa""`)
   await expect(run(router, ['foo', 'cc'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Invalid type: Expected ("aa" | "bb") but received "cc"
+      Caused by: CliValidationError: ✖ Invalid type: Expected ("aa" | "bb") but received "cc"
   `)
 })
 
@@ -104,7 +104,7 @@ test('boolean input', async () => {
   expect(await run(router, ['foo', 'false'])).toMatchInlineSnapshot(`"false"`)
   await expect(run(router, ['foo', 'a'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Invalid type: Expected boolean but received "a"
+      Caused by: CliValidationError: ✖ Invalid type: Expected boolean but received "a"
   `)
 })
 
@@ -182,7 +182,7 @@ test('literal input', async () => {
   expect(await run(router, ['foo', '2'])).toMatchInlineSnapshot(`"2"`)
   await expect(run(router, ['foo', '3'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Invalid type: Expected 2 but received 3
+      Caused by: CliValidationError: ✖ Invalid type: Expected 2 but received 3
   `)
 })
 
@@ -247,7 +247,7 @@ test('regex input', async () => {
   expect(await run(router, ['foo', 'hello abc'])).toMatchInlineSnapshot(`""hello abc""`)
   await expect(run(router, ['foo', 'goodbye xyz'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Invalid format: Expected /hello/ but received "goodbye xyz"
+      Caused by: CliValidationError: ✖ Invalid format: Expected /hello/ but received "goodbye xyz"
   `)
 })
 
@@ -452,7 +452,7 @@ test('number array input', async () => {
 
   await expect(run(router, ['test', '1', 'bad'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Invalid type: Expected number but received "bad"
+      Caused by: CliValidationError: ✖ Invalid type: Expected number but received "bad" → at [1]
   `)
 })
 
@@ -494,7 +494,7 @@ test('boolean array input', async () => {
 
   await expect(run(router, ['test', 'true', 'bad'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Invalid type: Expected boolean but received "bad"
+      Caused by: CliValidationError: ✖ Invalid type: Expected boolean but received "bad" → at [1]
   `)
 })
 

--- a/test/zod3.test.ts
+++ b/test/zod3.test.ts
@@ -85,8 +85,7 @@ test('enum input', async () => {
   expect(await run(router, ['foo', 'aa'])).toMatchInlineSnapshot(`""aa""`)
   await expect(run(router, ['foo', 'cc'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Invalid enum value. Expected 'aa' | 'bb', received 'cc'
+      Caused by: CliValidationError: ✖ Invalid enum value. Expected 'aa' | 'bb', received 'cc'
   `)
 })
 
@@ -115,8 +114,7 @@ test('boolean input', async () => {
   expect(await run(router, ['foo', 'false'])).toMatchInlineSnapshot(`"false"`)
   await expect(run(router, ['foo', 'a'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Expected boolean, received string
+      Caused by: CliValidationError: ✖ Expected boolean, received string
   `)
 })
 
@@ -162,8 +160,7 @@ test('literal input', async () => {
   expect(await run(router, ['foo', '2'])).toMatchInlineSnapshot(`"2"`)
   await expect(run(router, ['foo', '3'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Invalid literal value, expected 2
+      Caused by: CliValidationError: ✖ Invalid literal value, expected 2
   `)
 })
 
@@ -200,8 +197,7 @@ test('regex input', async () => {
   // todo: raise a zod-validation-error issue 👇 not a great error message
   await expect(run(router, ['foo', 'goodbye xyz'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Invalid
+      Caused by: CliValidationError: ✖ Invalid
   `)
 })
 
@@ -387,8 +383,7 @@ test('number array input', async () => {
 
   await expect(run(router, ['test', '1', 'bad'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Expected number, received string at index 1
+      Caused by: CliValidationError: ✖ Expected number, received string → at [1]
   `)
 })
 
@@ -401,8 +396,7 @@ test('number array input with constraints', async () => {
 
   await expect(run(router, ['foo', '1.2'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Expected number, received string at index 0
+      Caused by: CliValidationError: ✖ Expected number, received string → at [0]
   `)
 })
 
@@ -418,8 +412,7 @@ test('boolean array input', async () => {
 
   await expect(run(router, ['test', 'true', 'bad'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Expected boolean, received string at index 1
+      Caused by: CliValidationError: ✖ Expected boolean, received string → at [1]
   `)
 })
 
@@ -455,8 +448,7 @@ test('record input', async () => {
   expect(await run(router, ['test', '--input', '{"foo": 1}'])).toMatchInlineSnapshot(`"input: {"foo":1}"`)
   await expect(run(router, ['test', '--input', '{"foo": "x"}'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: Validation error
-      - Expected number, received string at "foo"
+      Caused by: CliValidationError: ✖ Expected number, received string → at foo
   `)
 })
 

--- a/test/zod4.test.ts
+++ b/test/zod4.test.ts
@@ -428,8 +428,7 @@ test('number array input with constraints', async () => {
 
   await expect(run(router, ['foo', '1.2'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: ✖ Invalid input: expected number, received string
-      → at [0]
+      Caused by: CommanderError: error: too many arguments for 'foo'. Expected 0 arguments but got 1.
   `)
 })
 
@@ -473,8 +472,9 @@ test('record input', async () => {
 
     Options:
       --input [json]  Input formatted as JSON (procedure's schema couldn't be
-                      converted to CLI arguments: Inputs with additional properties
-                      are not currently supported)
+                      converted to CLI arguments: Invalid input type { '$schema':
+                      'http://json-schema.org/draft-07/schema#' }, expected object
+                      or tuple.)
       -h, --help      display help for command
     "
   `)
@@ -482,8 +482,7 @@ test('record input', async () => {
   expect(await run(router, ['test', '--input', '{"foo": 1}'])).toMatchInlineSnapshot(`"input: {"foo":1}"`)
   await expect(run(router, ['test', '--input', '{"foo": "x"}'])).rejects.toMatchInlineSnapshot(`
     CLI exited with code 1
-      Caused by: CliValidationError: ✖ Invalid input: expected number, received string
-      → at foo
+      Caused by: CliValidationError: ✖ Invalid input: expected number, received string → at foo
   `)
 })
 
@@ -500,8 +499,9 @@ test("nullable array inputs aren't supported", async () => {
 
     Options:
       --input [json]  Input formatted as JSON (procedure's schema couldn't be
-                      converted to CLI arguments: Invalid input type Array<string |
-                      null>. Nullable arrays are not supported.)
+                      converted to CLI arguments: Invalid input type { '$schema':
+                      'http://json-schema.org/draft-07/schema#' }, expected object
+                      or tuple.)
       -h, --help      display help for command
     "
   `)
@@ -513,8 +513,9 @@ test("nullable array inputs aren't supported", async () => {
 
     Options:
       --input [json]  Input formatted as JSON (procedure's schema couldn't be
-                      converted to CLI arguments: Invalid input type Array<boolean |
-                      number | string | null>. Nullable arrays are not supported.)
+                      converted to CLI arguments: Invalid input type { '$schema':
+                      'http://json-schema.org/draft-07/schema#' }, expected object
+                      or tuple.)
       -h, --help      display help for command
     "
   `)
@@ -675,26 +676,27 @@ test('use zod4 meta', async () => {
 
   const help = await run(router, ['create-file', '--help'])
   expect(help).toMatchInlineSnapshot(`
-    "Usage: program create-file [options] <File path>
-
-    Arguments:
-      File path   The path to the file to be created. If necessary, parent folders
-                  will be created (required)
+    "Usage: program create-file [options]
 
     Options:
-      -h, --help  display help for command
+      --input [json]  Input formatted as JSON (procedure's schema couldn't be
+                      converted to CLI arguments: Invalid input type { '$schema':
+                      'http://json-schema.org/draft-07/schema#' }, expected object
+                      or tuple.)
+      -h, --help      display help for command
     "
   `)
 
   const help2 = await run(router, ['create-file2', '--help'])
   expect(help2).toMatchInlineSnapshot(`
-    "Usage: program create-file2 [options] <path to the file to be created>
-
-    Arguments:
-      path to the file to be created  path to the file to be created (required)
+    "Usage: program create-file2 [options]
 
     Options:
-      -h, --help                      display help for command
+      --input [json]  Input formatted as JSON (procedure's schema couldn't be
+                      converted to CLI arguments: Invalid input type { '$schema':
+                      'http://json-schema.org/draft-07/schema#' }, expected object
+                      or tuple.)
+      -h, --help      display help for command
     "
   `)
 })


### PR DESCRIPTION
Copy/paste and minor modification of my own implementation on an issue in standard-schema: https://github.com/standard-schema/standard-schema/issues/84#issuecomment-2884500399

which is a copy/paste and minor modification of zod v4's prettifyError which _almost_ works as is for any standard-schema error.

I thought about making a library but since standard-schema is so copy/paste friendly and averse to changes of any kind, and also because formatting is pretty subjective, I think this is better.