### PR TITLE
negate all booleans

### DIFF
--- a/test/arktype.test.ts
+++ b/test/arktype.test.ts
@@ -517,6 +517,7 @@ test('defaults and negations', async () => {
 
   expect(await run(router, ['optional-boolean'])).toMatchInlineSnapshot(`"{}"`)
   expect(await run(router, ['optional-boolean', '--foo'])).toMatchInlineSnapshot(`"{ foo: true }"`)
+  expect(await run(router, ['optional-boolean', '--no-foo'])).toMatchInlineSnapshot(`"{ foo: false }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'true'])).toMatchInlineSnapshot(`"{ foo: true }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'false'])).toMatchInlineSnapshot(`"{ foo: false }"`)
 

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -418,6 +418,7 @@ test('fs copy help', async () => {
 
     Options:
       --force [boolean]  Overwrite destination if it exists (default: false)
+      --no-force         Negate \`--force\` option.
       -h, --help         display help for command
     "
   `)
@@ -479,7 +480,9 @@ test('fs copy', async () => {
 
     Options:
       --ignore-whitespace [boolean]  Ignore whitespace changes (default: false)
+      --no-ignore-whitespace         Negate \`--ignore-whitespace\` option.
       --trim [boolean]               Trim start/end whitespace (default: false)
+      --no-trim                      Negate \`--trim\` option.
       -h, --help                     display help for command
     "
   `)
@@ -495,7 +498,9 @@ test('fs diff', async () => {
 
     Options:
       --ignore-whitespace [boolean]  Ignore whitespace changes (default: false)
+      --no-ignore-whitespace         Negate \`--ignore-whitespace\` option.
       --trim [boolean]               Trim start/end whitespace (default: false)
+      --no-trim                      Negate \`--trim\` option.
       -h, --help                     display help for command
     "
   `)

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -50,6 +50,7 @@ test('options with various modifiers', async () => {
           unionWithDefault: z.union([z.literal('foo'), z.literal('bar')]).default('foo'),
           numberWithDefault: z.number().default(42),
           booleanWithDefault: z.boolean().default(true),
+          booleanOrNumber: z.union([z.boolean(), z.number()]),
           enumWithDefault: z.enum(['foo', 'bar']).default('foo'),
           arrayWithDefault: z.array(z.string()).default(['hello']),
           objectWithDefault: z.object({foo: z.string()}).default({foo: 'bar'}),
@@ -75,8 +76,10 @@ test('options with various modifiers', async () => {
       --literal-with-default [string]               Const: hi (default: "hi")
       --union-with-default [string]                 (choices: "foo", "bar", default: "foo")
       --number-with-default [number]                (default: 42)
-      --no-boolean-with-default                     Negate \`--boolean-with-default\` option.
       --boolean-with-default [boolean]              (default: true)
+      --no-boolean-with-default                     Negate \`--boolean-with-default\` option.
+      --boolean-or-number [value]                   type: boolean or number (default: false)
+      --no-boolean-or-number                        Negate \`--boolean-or-number\` option.
       --enum-with-default [string]                  (choices: "foo", "bar", default: "foo")
       --array-with-default [values...]              Type: string array (default: ["hello"])
       --object-with-default [json]                  Object (json formatted); Required: ["foo"] (default: {"foo":"bar"})

--- a/test/valibot.test.ts
+++ b/test/valibot.test.ts
@@ -531,6 +531,7 @@ test('defaults and negations', async () => {
 
   expect(await run(router, ['optional-boolean'])).toMatchInlineSnapshot(`"{}"`)
   expect(await run(router, ['optional-boolean', '--foo'])).toMatchInlineSnapshot(`"{ foo: true }"`)
+  expect(await run(router, ['optional-boolean', '--no-foo'])).toMatchInlineSnapshot(`"{ foo: false }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'true'])).toMatchInlineSnapshot(`"{ foo: true }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'false'])).toMatchInlineSnapshot(`"{ foo: false }"`)
 

--- a/test/zod3.test.ts
+++ b/test/zod3.test.ts
@@ -516,6 +516,7 @@ test('defaults and negations', async () => {
 
   expect(await run(router, ['optional-boolean'])).toMatchInlineSnapshot(`"{}"`)
   expect(await run(router, ['optional-boolean', '--foo'])).toMatchInlineSnapshot(`"{ foo: true }"`)
+  expect(await run(router, ['optional-boolean', '--no-foo'])).toMatchInlineSnapshot(`"{ foo: false }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'true'])).toMatchInlineSnapshot(`"{ foo: true }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'false'])).toMatchInlineSnapshot(`"{ foo: false }"`)
 

--- a/test/zod4.test.ts
+++ b/test/zod4.test.ts
@@ -561,6 +561,7 @@ test('defaults and negations', async () => {
 
   expect(await run(router, ['optional-boolean'])).toMatchInlineSnapshot(`"{}"`)
   expect(await run(router, ['optional-boolean', '--foo'])).toMatchInlineSnapshot(`"{ foo: true }"`)
+  expect(await run(router, ['optional-boolean', '--no-foo'])).toMatchInlineSnapshot(`"{ foo: false }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'true'])).toMatchInlineSnapshot(`"{ foo: true }"`)
   expect(await run(router, ['optional-boolean', '--foo', 'false'])).toMatchInlineSnapshot(`"{ foo: false }"`)
 


### PR DESCRIPTION
this enables two nice things:

1)
"scripts": {
  "abc": "mycli --foo"
}

pnpm abc // {foo: true}
pnpm abc --no-foo // {foo: false}

2)
now, if you do `foo: z.boolean().optional()` as an option:

mycli --foo // {foo: true}
mycli --no-foo // {foo: false}
mycli // {} (no foo property at all)

and your cli can add custom behaviour when options.foo === undefined e.g. prompting for the user to decide if they want `foo` or not, definitively

cc @AmanVarshney01