### PR TITLE
feat: add hidden option support via zod meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,7 +1207,7 @@ Note - in the above example `src/your-router.ts` will be imported, and then its 
 ### API docs
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/index.ts, export: createCli} -->
-#### [createCli](./src/index.ts#L211)
+#### [createCli](./src/index.ts#L219)
 
 Run a trpc router as a CLI.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,10 @@ declare module 'zod/v4' {
      * Note: this is only valid for options, not positional arguments.
      */
     alias?: string
+    /**
+     * If true, this option will not appear in the --help output but will still be functional.
+     */
+    hidden?: boolean
   }
 }
 
@@ -74,6 +78,10 @@ declare module 'zod' {
      * Note: this is only valid for options, not positional arguments.
      */
     alias?: string
+    /**
+     * If true, this option will not appear in the --help output but will still be functional.
+     */
+    hidden?: boolean
   }
 }
 
@@ -312,6 +320,13 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
           delete unusedOptionAliases[propertyKey]
         }
 
+
+        const isHidden = 'hidden' in propertyValue && propertyValue.hidden === true
+        const addOption = (opt: InstanceType<typeof BaseOption>) => {
+          if (isHidden) opt.hideHelp()
+          command.addOption(opt)
+        }
+
         const allowedSchemas = getAllowedSchemas(propertyValue)
         const firstSchemaWithDefault = allowedSchemas.find(subSchema => 'default' in subSchema)
         // Check for default value - first in the allowed schemas, then on the root property itself
@@ -347,7 +362,7 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
           const option = new Option(`${flags} ${bracketise('string')}`, description)
           option.choices(enumChoices.choices)
           if (defaultValue.exists) option.default(defaultValue.value)
-          command.addOption(option)
+          addOption(option)
           return
         }
 
@@ -356,7 +371,7 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
           if (defaultValue.exists) option.default(defaultValue.value)
           else if (rootTypes.includes('boolean')) option.default(false)
           option.argParser(getOptionValueParser(propertyValue))
-          command.addOption(option)
+          addOption(option)
           if (rootTypes.includes('boolean')) negate()
           return
         }
@@ -364,7 +379,7 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
         if (rootTypes.length !== 1) {
           const option = new Option(`${flags} ${bracketise('json')}`, description)
           option.argParser(getOptionValueParser(propertyValue))
-          command.addOption(option)
+          addOption(option)
           return
         }
 
@@ -374,7 +389,7 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
           // don't set a default value of `false`, because `undefined` is accepted by the procedure
           if (isValueRequired) option.default(false)
           else if (defaultValue.exists) option.default(defaultValue.value)
-          command.addOption(option)
+          addOption(option)
           negate()
           return
         }
@@ -434,7 +449,7 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
           }),
         )
 
-        command.addOption(option)
+        addOption(option)
         if (propertyType === 'boolean') negate() // just in case we refactor the code above and don't handle booleans as a special case
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,7 +320,6 @@ export function createCli<R extends AnyRouter>({router, ...params}: TrpcCliParam
           delete unusedOptionAliases[propertyKey]
         }
 
-
         const isHidden = 'hidden' in propertyValue && propertyValue.hidden === true
         const addOption = (opt: InstanceType<typeof BaseOption>) => {
           if (isHidden) opt.hideHelp()

--- a/test/zod4.test.ts
+++ b/test/zod4.test.ts
@@ -830,6 +830,28 @@ test('complex positionals', async () => {
   )
 })
 
+test('hidden option via zod meta', async () => {
+  const router = t.router({
+    test: t.procedure
+      .input(
+        z.object({
+          visible: z.string().optional(),
+          secret: z.string().optional().meta({hidden: true}),
+        }),
+      )
+      .mutation(({input}) => JSON.stringify(input)),
+  })
+
+  const help = await run(router, ['test', '--help'])
+  expect(help).toContain('--visible')
+  expect(help).not.toContain('--secret')
+
+  expect(await run(router, ['test', '--secret', 'shhh'])).toMatchInlineSnapshot(`"{"secret":"shhh"}"`)
+  expect(await run(router, ['test', '--visible', 'hi', '--secret', 'shhh'])).toMatchInlineSnapshot(
+    `"{"visible":"hi","secret":"shhh"}"`,
+  )
+})
+
 {
   // type errors for invalid meta
   // @ts-expect-error - positional is a boolean


### PR DESCRIPTION
### Summary
- Adds support for `hidden` property in zod `.meta({ hidden: true })` to hide options from `--help` output while keeping them fully functional
- Uses Commander's `hideHelp()` under the hood, applied through a local `addOption` wrapper to avoid repetition across branches
- Adds type declarations for both `zod` and `zod/v4` module augmentation

### Test plan
- [x] Added test in `zod4.test.ts` verifying hidden options are excluded from `--help`
- [x] Added test verifying hidden options still accept and parse values correctly
- [x] All 44 existing zod4 tests continue to pass