### PR TITLE
add auto table logger

### DIFF
--- a/src/cli-table.ts
+++ b/src/cli-table.ts
@@ -1,0 +1,230 @@
+/*
+ * Based on cli-table v0.3.11 (MIT), adapted and inlined for trpc-cli.
+ * Original project: https://github.com/Automattic/cli-table
+ * Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+ */
+
+type Cell = {text: string; width?: number} | string | number | boolean | bigint | null | undefined
+type Row = Cell[]
+type ObjectRow = Record<string, Cell | Cell[]>
+type TableRow = Row | ObjectRow
+
+export interface CliTableOptions {
+  chars?: Partial<typeof defaultChars>
+  truncate?: string
+  colWidths?: number[]
+  colAligns?: Array<'left' | 'right' | 'middle'>
+  style?: Partial<typeof defaultStyle>
+  head?: string[]
+  rows?: TableRow[]
+}
+
+const defaultChars = {
+  top: '─',
+  'top-mid': '┬',
+  'top-left': '┌',
+  'top-right': '┐',
+  bottom: '─',
+  'bottom-mid': '┴',
+  'bottom-left': '└',
+  'bottom-right': '┘',
+  left: '│',
+  'left-mid': '├',
+  mid: '─',
+  'mid-mid': '┼',
+  right: '│',
+  'right-mid': '┤',
+  middle: '│',
+}
+
+const defaultStyle = {
+  'padding-left': 1,
+  'padding-right': 1,
+  head: [] as string[],
+  border: [] as string[],
+  compact: false,
+}
+
+export class CliTable extends Array<TableRow> {
+  options: Required<Pick<CliTableOptions, 'truncate' | 'colWidths' | 'colAligns' | 'head'>> & {
+    chars: typeof defaultChars
+    style: typeof defaultStyle
+  }
+
+  constructor(options: CliTableOptions = {}) {
+    super()
+    this.options = {
+      chars: {...defaultChars, ...options.chars},
+      truncate: options.truncate ?? '…',
+      colWidths: [...(options.colWidths ?? [])],
+      colAligns: [...(options.colAligns ?? [])],
+      style: {...defaultStyle, ...options.style},
+      head: [...(options.head ?? [])],
+    }
+    for (const row of options.rows ?? []) this.push(row)
+  }
+
+  get width() {
+    const line = this.toString().split('\n')[0]
+    return line?.length ?? 0
+  }
+
+  override toString() {
+    const {chars, head, style, truncate} = this.options
+    const colWidths = [...this.options.colWidths]
+    let out = ''
+
+    if (!head.length && !this.length) return ''
+
+    if (!colWidths.length) {
+      const allRows = head.length ? [...this, head] : [...this]
+      for (const row of allRows) extractColumnWidths(row)
+    }
+
+    const totalWidth =
+      (colWidths.length === 1 ? colWidths[0] : colWidths.reduce((a, b) => a + b, 0)) + colWidths.length + 1
+
+    const drawLine = (fill: string, left: string, right: string, join: string) => {
+      let width = 0
+      let line = left + repeat(fill, totalWidth - 2) + right
+      colWidths.forEach((columnWidth, index) => {
+        if (index === colWidths.length - 1) return
+        width += columnWidth + 1
+        line = line.slice(0, width) + join + line.slice(width + 1)
+      })
+      return line
+    }
+
+    const lineTop = () => {
+      const line = drawLine(chars.top, chars['top-left'], chars['top-right'], chars['top-mid'])
+      if (line) out += line + '\n'
+    }
+
+    const stringifyCell = (cell: Cell, index: number) => {
+      const text = String(typeof cell === 'object' && cell && 'text' in cell ? cell.text : (cell ?? ''))
+      const visibleLength = strlen(text)
+      const width = colWidths[index] - style['padding-left'] - style['padding-right']
+      const align = this.options.colAligns[index] ?? 'left'
+      const body =
+        visibleLength === width
+          ? text
+          : visibleLength < width
+            ? pad(
+                text,
+                width + (text.length - visibleLength),
+                ' ',
+                align === 'left' ? 'right' : align === 'middle' ? 'both' : 'left',
+              )
+            : truncateText(text, width, truncate)
+      return repeat(' ', style['padding-left']) + body + repeat(' ', style['padding-right'])
+    }
+
+    const renderRow = (items: TableRow) => {
+      const normalized = normalizeRow(items)
+      const cells = normalized.map((item, index) => {
+        const contents = String(typeof item === 'object' && item && 'text' in item ? item.text : (item ?? ''))
+          .split('\n')
+          .map(line => stringifyCell(line, index))
+        return {contents, height: contents.length}
+      })
+      const maxHeight = Math.max(...cells.map(cell => cell.height), 0)
+      const lines = Array.from({length: maxHeight}, () => [] as string[])
+
+      cells.forEach((cell, index) => {
+        cell.contents.forEach((line, lineIndex) => {
+          lines[lineIndex].push(line)
+        })
+        for (let lineIndex = cell.height; lineIndex < maxHeight; lineIndex++) {
+          lines[lineIndex].push(stringifyCell('', index))
+        }
+      })
+
+      const body = lines.map(line => line.join(chars.middle) + chars.right).join('\n' + chars.left)
+
+      return chars.left + body
+    }
+
+    if (head.length) {
+      lineTop()
+      out += renderRow(head) + '\n'
+    }
+
+    this.forEach((row, index) => {
+      if (!head.length && index === 0) {
+        lineTop()
+      } else if (!style.compact || index < (head.length ? 1 : 0) || row.length === 0) {
+        const line = drawLine(chars.mid, chars['left-mid'], chars['right-mid'], chars['mid-mid'])
+        if (line) out += line + '\n'
+      }
+
+      if (hasLength(row) && row.length === 0) return
+      out += renderRow(row) + '\n'
+    })
+
+    const bottom = drawLine(chars.bottom, chars['bottom-left'], chars['bottom-right'], chars['bottom-mid'])
+    return bottom ? out + bottom : out.slice(0, -1)
+
+    function extractColumnWidths(row: TableRow, offset = 0) {
+      if (Array.isArray(row)) {
+        row.forEach((cell, index) => {
+          colWidths[index + offset] = Math.max(colWidths[index + offset] ?? 0, getWidth(cell))
+        })
+        return
+      }
+
+      const [headerCell, valueCell] = Object.entries(row)[0] ?? []
+      if (headerCell == null) return
+      colWidths[offset] = Math.max(colWidths[offset] ?? 0, getWidth(headerCell))
+      if (Array.isArray(valueCell)) {
+        valueCell.forEach((cell, index) => {
+          colWidths[offset + index + 1] = Math.max(colWidths[offset + index + 1] ?? 0, getWidth(cell))
+        })
+        return
+      }
+      colWidths[offset + 1] = Math.max(colWidths[offset + 1] ?? 0, getWidth(valueCell))
+    }
+
+    function getWidth(cell: Cell) {
+      const content =
+        typeof cell === 'object' && cell && 'width' in cell && typeof cell.width === 'number'
+          ? cell.width
+          : strlen(typeof cell === 'object' && cell && 'text' in cell ? cell.text : String(cell ?? ''))
+      return content + style['padding-left'] + style['padding-right']
+    }
+
+    function normalizeRow(row: TableRow): Row {
+      if (Array.isArray(row)) return row
+      const [key, value] = Object.entries(row)[0] ?? []
+      if (key == null) return []
+      return Array.isArray(value) ? [key, ...value] : [key, value]
+    }
+
+    function hasLength(row: TableRow): row is {length: number} {
+      return 'length' in row
+    }
+  }
+}
+
+const repeat = (value: string, times: number) => Array.from({length: times}, () => value).join('')
+
+const pad = (value: string, len: number, padChar: string, direction: 'left' | 'right' | 'both') => {
+  if (len + 1 < value.length) return value
+  if (direction === 'left') return repeat(padChar, len - value.length) + value
+  if (direction === 'both') {
+    const padLength = len - value.length
+    const right = Math.ceil(padLength / 2)
+    const left = padLength - right
+    return repeat(padChar, left) + value + repeat(padChar, right)
+  }
+  return value + repeat(padChar, len - value.length)
+}
+
+const truncateText = (value: string, length: number, truncater: string) =>
+  value.length >= length ? value.slice(0, length - truncater.length) + truncater : value
+
+const strlen = (value: unknown) => {
+  const stripped = String(value).replaceAll(ansiColorPattern, '')
+  return stripped.split('\n').reduce((max, line) => Math.max(max, line.length), 0)
+}
+
+const ansiColorPattern = new RegExp(String.raw`\u001b\[(?:\d*;){0,5}\d*m`, 'g')

--- a/src/cli-table.ts
+++ b/src/cli-table.ts
@@ -6,7 +6,7 @@
 
 type Cell = {text: string; width?: number} | string | number | boolean | bigint | null | undefined
 type Row = Cell[]
-type ObjectRow = Record<string, Cell | Cell[]>
+type ObjectRow = {[key: string]: Cell | Cell[]}
 type TableRow = Row | ObjectRow
 
 export interface CliTableOptions {
@@ -172,7 +172,7 @@ export class CliTable extends Array<TableRow> {
         return
       }
 
-      const [headerCell, valueCell] = Object.entries(row)[0] ?? []
+      const [headerCell, valueCell] = getSingleObjectEntry(row)
       if (headerCell == null) return
       colWidths[offset] = Math.max(colWidths[offset] ?? 0, getWidth(headerCell))
       if (Array.isArray(valueCell)) {
@@ -194,9 +194,17 @@ export class CliTable extends Array<TableRow> {
 
     function normalizeRow(row: TableRow): Row {
       if (Array.isArray(row)) return row
-      const [key, value] = Object.entries(row)[0] ?? []
+      const [key, value] = getSingleObjectEntry(row)
       if (key == null) return []
       return Array.isArray(value) ? [key, ...value] : [key, value]
+    }
+
+    function getSingleObjectEntry(row: ObjectRow) {
+      const entries = Object.entries(row)
+      if (entries.length > 1) {
+        throw new Error(`CliTable object rows must contain exactly one entry. Got ${entries.length}.`)
+      }
+      return entries[0] ?? []
     }
 
     function hasLength(row: TableRow): row is {length: number} {

--- a/src/index.ts
+++ b/src/index.ts
@@ -611,6 +611,7 @@ function transformError(err: unknown, command: Command) {
 
 export {FailedToExitError, CliValidationError} from './errors.js'
 export {getCliContext, type CliContextValue, type CliCommand} from './context.js'
+export {autoTableConsoleLogger, autoTableLogger, lineByLineConsoleLogger, lineByLineLogger} from './logging.js'
 
 const numberParser = (val: string, {fallback = val as unknown} = {}) => {
   const number = Number(val)

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,3 +1,4 @@
+import {CliTable} from './cli-table.js'
 import {Log, Logger} from './types.js'
 
 export const lineByLineLogger = getLoggerTransformer(log => {
@@ -20,10 +21,91 @@ export const lineByLineLogger = getLoggerTransformer(log => {
   return (...args) => wrapper(args, 0)
 })
 
+type Primitive = string | number | boolean | bigint | null | undefined
+type FlatRecord = Record<string, Primitive>
+
+export const autoTableLogger = getLoggerTransformer(log => (...args) => {
+  if (args.length > 1 && args.every(isPrimitive)) {
+    log(...args)
+    return
+  }
+
+  log(formatLogArgs(args))
+})
+
 const isPrimitive = (value: unknown): value is string | number | boolean => {
   const type = typeof value
   return type === 'string' || type === 'number' || type === 'boolean'
 }
+
+const isDisplayPrimitive = (value: unknown): value is Primitive =>
+  value == null || isPrimitive(value) || typeof value === 'bigint'
+
+const formatLogArgs = (args: unknown[]) => {
+  if (args.length !== 1) return JSON.stringify(args, null, 2)
+  return renderValue(args[0])
+}
+
+const renderValue = (value: unknown, heading?: string): string => {
+  if (Array.isArray(value) && value.every(isFlatRecord)) {
+    const body = value.length ? renderRowsTable(value) : '[]'
+    return withHeading(heading, body)
+  }
+
+  if (Array.isArray(value) && value.every(isDisplayPrimitive)) {
+    return withHeading(heading, value.map(String).join('\n'))
+  }
+
+  if (isFlatRecord(value)) {
+    return withHeading(heading, renderKeyValueTable(value))
+  }
+
+  if (isDisplayPrimitive(value)) {
+    return withHeading(heading, String(value))
+  }
+
+  if (isRecord(value)) {
+    const sections = Object.entries(value)
+      .map(([key, nested]) => renderValue(nested, key))
+      .filter(Boolean)
+    if (sections.length) return sections.join('\n\n')
+  }
+
+  return withHeading(heading, JSON.stringify(value, null, 2))
+}
+
+const renderRowsTable = (rows: FlatRecord[]) => {
+  const columns = Array.from(new Set(rows.flatMap(row => Object.keys(row))))
+  const table = new CliTable({head: columns})
+
+  for (const row of rows) {
+    table.push(columns.map(column => formatCell(row[column])))
+  }
+
+  return table.toString()
+}
+
+const renderKeyValueTable = (row: FlatRecord) => {
+  const table = new CliTable({head: ['field', 'value']})
+
+  for (const [field, value] of Object.entries(row)) {
+    table.push([field, formatCell(value)])
+  }
+
+  return table.toString()
+}
+
+const formatCell = (value: Primitive) => (value == null ? '' : String(value))
+
+const withHeading = (heading: string | undefined, body: string) => (heading ? `${heading}:\n${body}` : body)
+
+const isFlatRecord = (value: unknown): value is FlatRecord => {
+  if (!isRecord(value)) return false
+  return Object.values(value).every(isDisplayPrimitive)
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value)
 
 /** Takes a function that wraps an individual log function, and returns a function that wraps the `info` and `error` functions for a logger */
 function getLoggerTransformer(transform: (log: Log) => Log) {
@@ -43,3 +125,4 @@ function getLoggerTransformer(transform: (log: Log) => Log) {
  * This is useful for logging structured data in a human-readable way, and for piping logs to other tools.
  */
 export const lineByLineConsoleLogger = lineByLineLogger(console)
+export const autoTableConsoleLogger = autoTableLogger(console)

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -25,7 +25,7 @@ type Primitive = string | number | boolean | bigint | null | undefined
 type FlatRecord = Record<string, Primitive>
 
 export const autoTableLogger = getLoggerTransformer(log => (...args) => {
-  if (args.length > 1 && args.every(isPrimitive)) {
+  if (args.length > 1 && args.every(isDisplayPrimitive)) {
     log(...args)
     return
   }
@@ -42,11 +42,11 @@ const isDisplayPrimitive = (value: unknown): value is Primitive =>
   value == null || isPrimitive(value) || typeof value === 'bigint'
 
 const formatLogArgs = (args: unknown[]) => {
-  if (args.length !== 1) return JSON.stringify(args, null, 2)
-  return renderValue(args[0])
+  if (args.length !== 1) return safeJsonStringify(args)
+  return renderValue(args[0], undefined, new WeakSet<object>())
 }
 
-const renderValue = (value: unknown, heading?: string): string => {
+const renderValue = (value: unknown, heading: string | undefined, seen: WeakSet<object>): string => {
   if (Array.isArray(value) && value.every(isFlatRecord)) {
     const body = value.length ? renderRowsTable(value) : '[]'
     return withHeading(heading, body)
@@ -65,17 +65,23 @@ const renderValue = (value: unknown, heading?: string): string => {
   }
 
   if (isRecord(value)) {
+    if (seen.has(value)) return withHeading(heading, '[Circular]')
+    seen.add(value)
     const sections = Object.entries(value)
-      .map(([key, nested]) => renderValue(nested, key))
+      .map(([key, nested]) => renderValue(nested, key, seen))
       .filter(Boolean)
     if (sections.length) return sections.join('\n\n')
   }
 
-  return withHeading(heading, JSON.stringify(value, null, 2))
+  return withHeading(heading, safeJsonStringify(value))
 }
 
 const renderRowsTable = (rows: FlatRecord[]) => {
-  const columns = Array.from(new Set(rows.flatMap(row => Object.keys(row))))
+  const firstRowColumns = rows[0] ? Object.keys(rows[0]) : []
+  const extraColumns = Array.from(new Set(rows.flatMap(row => Object.keys(row))))
+    .filter(column => !firstRowColumns.includes(column))
+    .sort()
+  const columns = [...firstRowColumns, ...extraColumns]
   const table = new CliTable({head: columns})
 
   for (const row of rows) {
@@ -106,6 +112,22 @@ const isFlatRecord = (value: unknown): value is FlatRecord => {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === 'object' && !Array.isArray(value)
+
+const safeJsonStringify = (value: unknown) => {
+  const seen = new WeakSet<object>()
+  return JSON.stringify(
+    value,
+    (_key, currentValue: unknown) => {
+      if (typeof currentValue === 'bigint') return String(currentValue)
+      if (!currentValue || typeof currentValue !== 'object') return currentValue
+      const objectValue: object = currentValue
+      if (seen.has(objectValue)) return '[Circular]'
+      seen.add(objectValue)
+      return objectValue
+    },
+    2,
+  )
+}
 
 /** Takes a function that wraps an individual log function, and returns a function that wraps the `info` and `error` functions for a logger */
 function getLoggerTransformer(transform: (log: Log) => Log) {

--- a/test/cli-table.test.ts
+++ b/test/cli-table.test.ts
@@ -1,0 +1,236 @@
+import {expect, test} from 'vitest'
+
+import {CliTable} from '../src/cli-table.js'
+
+test('complete table', () => {
+  const table = new CliTable({
+    head: ['Rel', 'Change', 'By', 'When'],
+    colWidths: [6, 21, 25, 17],
+  })
+
+  table.push(
+    ['v0.1', 'Testing something cool', 'rauchg@gmail.com', '7 minutes ago'],
+    ['v0.1', 'Testing something cool', 'rauchg@gmail.com', '8 minutes ago'],
+  )
+
+  expect(table.toString()).toBe(
+    [
+      '┌──────┬─────────────────────┬─────────────────────────┬─────────────────┐',
+      '│ Rel  │ Change              │ By                      │ When            │',
+      '├──────┼─────────────────────┼─────────────────────────┼─────────────────┤',
+      '│ v0.1 │ Testing something … │ rauchg@gmail.com        │ 7 minutes ago   │',
+      '├──────┼─────────────────────┼─────────────────────────┼─────────────────┤',
+      '│ v0.1 │ Testing something … │ rauchg@gmail.com        │ 8 minutes ago   │',
+      '└──────┴─────────────────────┴─────────────────────────┴─────────────────┘',
+    ].join('\n'),
+  )
+})
+
+test('width property', () => {
+  const table = new CliTable({head: ['Cool']})
+  expect(table.width).toBe(8)
+})
+
+test('vertical table output', () => {
+  const table = new CliTable({
+    style: {'padding-left': 0, 'padding-right': 0},
+  })
+
+  table.push({'v0.1': 'Testing something cool'}, {'v0.1': 'Testing something cool'})
+
+  expect(table.toString()).toBe(
+    [
+      '┌────┬──────────────────────┐',
+      '│v0.1│Testing something cool│',
+      '├────┼──────────────────────┤',
+      '│v0.1│Testing something cool│',
+      '└────┴──────────────────────┘',
+    ].join('\n'),
+  )
+})
+
+test('cross table output', () => {
+  const table = new CliTable({
+    head: ['', 'Header 1', 'Header 2'],
+    style: {'padding-left': 0, 'padding-right': 0},
+  })
+
+  table.push({'Header 3': ['v0.1', 'Testing something cool']}, {'Header 4': ['v0.1', 'Testing something cool']})
+
+  expect(table.toString()).toBe(
+    [
+      '┌────────┬────────┬──────────────────────┐',
+      '│        │Header 1│Header 2              │',
+      '├────────┼────────┼──────────────────────┤',
+      '│Header 3│v0.1    │Testing something cool│',
+      '├────────┼────────┼──────────────────────┤',
+      '│Header 4│v0.1    │Testing something cool│',
+      '└────────┴────────┴──────────────────────┘',
+    ].join('\n'),
+  )
+})
+
+test('custom chars', () => {
+  const table = new CliTable({
+    chars: {
+      top: '═',
+      'top-mid': '╤',
+      'top-left': '╔',
+      'top-right': '╗',
+      bottom: '═',
+      'bottom-mid': '╧',
+      'bottom-left': '╚',
+      'bottom-right': '╝',
+      left: '║',
+      'left-mid': '╟',
+      right: '║',
+      'right-mid': '╢',
+    },
+  })
+
+  table.push(['foo', 'bar', 'baz'], ['frob', 'bar', 'quuz'])
+
+  expect(table.toString()).toBe(
+    [
+      '╔══════╤═════╤══════╗',
+      '║ foo  │ bar │ baz  ║',
+      '╟──────┼─────┼──────╢',
+      '║ frob │ bar │ quuz ║',
+      '╚══════╧═════╧══════╝',
+    ].join('\n'),
+  )
+})
+
+test('compact shorthand', () => {
+  const table = new CliTable({style: {compact: true}})
+
+  table.push(['foo', 'bar', 'baz'], ['frob', 'bar', 'quuz'])
+
+  expect(table.toString()).toBe(
+    ['┌──────┬─────┬──────┐', '│ foo  │ bar │ baz  │', '│ frob │ bar │ quuz │', '└──────┴─────┴──────┘'].join('\n'),
+  )
+})
+
+test('compact empty mid line', () => {
+  const table = new CliTable({
+    chars: {
+      mid: '',
+      'left-mid': '',
+      'mid-mid': '',
+      'right-mid': '',
+    },
+  })
+
+  table.push(['foo', 'bar', 'baz'], ['frob', 'bar', 'quuz'])
+
+  expect(table.toString()).toBe(
+    ['┌──────┬─────┬──────┐', '│ foo  │ bar │ baz  │', '│ frob │ bar │ quuz │', '└──────┴─────┴──────┘'].join('\n'),
+  )
+})
+
+test('decoration lines disabled', () => {
+  const table = new CliTable({
+    chars: {
+      top: '',
+      'top-mid': '',
+      'top-left': '',
+      'top-right': '',
+      bottom: '',
+      'bottom-mid': '',
+      'bottom-left': '',
+      'bottom-right': '',
+      left: '',
+      'left-mid': '',
+      mid: '',
+      'mid-mid': '',
+      right: '',
+      'right-mid': '',
+      middle: ' ',
+    },
+    style: {'padding-left': 0, 'padding-right': 0},
+  })
+
+  table.push(['foo', 'bar', 'baz'], ['frobnicate', 'bar', 'quuz'])
+
+  expect(table.toString()).toBe(['foo        bar baz ', 'frobnicate bar quuz'].join('\n'))
+})
+
+test('rows option in constructor', () => {
+  const table = new CliTable({
+    rows: [
+      ['foo', '7 minutes ago'],
+      ['bar', '8 minutes ago'],
+    ],
+  })
+
+  expect(table.toString()).toBe(
+    [
+      '┌─────┬───────────────┐',
+      '│ foo │ 7 minutes ago │',
+      '├─────┼───────────────┤',
+      '│ bar │ 8 minutes ago │',
+      '└─────┴───────────────┘',
+    ].join('\n'),
+  )
+})
+
+test('table with no options provided in constructor', () => {
+  expect(new CliTable()).toBeTruthy()
+})
+
+test('table with newlines in headers', () => {
+  const table = new CliTable({head: ['Test', '1\n2\n3']})
+
+  expect(table.toString()).toBe(
+    ['┌──────┬───┐', '│ Test │ 1 │', '│      │ 2 │', '│      │ 3 │', '└──────┴───┘'].join('\n'),
+  )
+})
+
+test('column width reflects newlines', () => {
+  const table = new CliTable({head: ['Test\nWidth']})
+  expect(table.width).toBe(9)
+})
+
+test('newlines in body cells', () => {
+  const table = new CliTable()
+
+  table.push(['something\nwith\nnewlines'])
+
+  expect(table.toString()).toBe(
+    ['┌───────────┐', '│ something │', '│ with      │', '│ newlines  │', '└───────────┘'].join('\n'),
+  )
+})
+
+test('newlines in vertical cell header and body', () => {
+  const table = new CliTable({
+    style: {'padding-left': 0, 'padding-right': 0},
+  })
+
+  table.push({'v\n0.1': 'Testing\nsomething cool'})
+
+  expect(table.toString()).toBe(
+    ['┌───┬──────────────┐', '│v  │Testing       │', '│0.1│something cool│', '└───┴──────────────┘'].join('\n'),
+  )
+})
+
+test('newlines in cross table header and body', () => {
+  const table = new CliTable({
+    head: ['', 'Header\n1'],
+    style: {'padding-left': 0, 'padding-right': 0},
+  })
+
+  table.push({'Header\n2': ['Testing\nsomething\ncool']})
+
+  expect(table.toString()).toBe(
+    [
+      '┌──────┬─────────┐',
+      '│      │Header   │',
+      '│      │1        │',
+      '├──────┼─────────┤',
+      '│Header│Testing  │',
+      '│2     │something│',
+      '│      │cool     │',
+      '└──────┴─────────┘',
+    ].join('\n'),
+  )
+})

--- a/test/cli-table.test.ts
+++ b/test/cli-table.test.ts
@@ -234,3 +234,11 @@ test('newlines in cross table header and body', () => {
     ].join('\n'),
   )
 })
+
+test('object rows must contain exactly one entry', () => {
+  const table = new CliTable()
+
+  table.push({a: 1, b: 2})
+
+  expect(() => table.toString()).toThrowError('CliTable object rows must contain exactly one entry. Got 2.')
+})

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -145,3 +145,41 @@ test('auto table for nested values', async () => {
     abc
   `)
 })
+
+test('auto table passes through display primitives', async () => {
+  tables.info!(1, 2n, null, undefined, false)
+
+  expect(info).toHaveBeenCalledWith(1, 2n, null, undefined, false)
+})
+
+test('auto table handles circular objects', async () => {
+  const value = {name: 'Ada'} as {name: string; self?: unknown}
+  value.self = value
+
+  tables.info!(value)
+
+  expect(info).toMatchInlineSnapshot(`
+    name:
+    Ada
+
+    self:
+    [Circular]
+  `)
+})
+
+test('auto table uses deterministic extra column ordering', async () => {
+  tables.info!([
+    {b: 'one', a: 'two'},
+    {c: 'three', b: 'four'},
+  ])
+
+  expect(info).toMatchInlineSnapshot(`
+    ┌──────┬─────┬───────┐
+    │ b    │ a   │ c     │
+    ├──────┼─────┼───────┤
+    │ one  │ two │       │
+    ├──────┼─────┼───────┤
+    │ four │     │ three │
+    └──────┴─────┴───────┘
+  `)
+})

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -1,10 +1,11 @@
 import {beforeEach, expect, test, vi} from 'vitest'
-import {lineByLineLogger} from '../src/logging.js'
+import {autoTableLogger, lineByLineLogger} from '../src/logging.js'
 
 const info = vi.fn()
 const error = vi.fn()
 const mocks = {info, error}
 const jsonish = lineByLineLogger(mocks)
+const tables = autoTableLogger(mocks)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -101,5 +102,46 @@ test('object array', async () => {
     {
       "name": "m3"
     }
+  `)
+})
+
+test('auto table for flat object arrays', async () => {
+  tables.info!([
+    {name: 'Ada', role: 'admin'},
+    {name: 'Linus', role: 'maintainer'},
+  ])
+
+  expect(info).toMatchInlineSnapshot(`
+    ┌───────┬────────────┐
+    │ name  │ role       │
+    ├───────┼────────────┤
+    │ Ada   │ admin      │
+    ├───────┼────────────┤
+    │ Linus │ maintainer │
+    └───────┴────────────┘
+  `)
+})
+
+test('auto table for nested values', async () => {
+  tables.info!({
+    foo: [
+      {job: 'typecheck', status: 'pass'},
+      {job: 'test', status: 'fail'},
+    ],
+    bar: 'abc',
+  })
+
+  expect(info).toMatchInlineSnapshot(`
+    foo:
+    ┌───────────┬────────┐
+    │ job       │ status │
+    ├───────────┼────────┤
+    │ typecheck │ pass   │
+    ├───────────┼────────┤
+    │ test      │ fail   │
+    └───────────┴────────┘
+
+    bar:
+    abc
   `)
 })


### PR DESCRIPTION
## Summary
- inline a minimal MIT-licensed `cli-table` implementation so table rendering is a first-class built-in feature with no runtime dependency
- add exported `autoTableLogger` helpers that render flat arrays as tables, flat objects as key/value tables, and nested objects as named sections while keeping JSON as the default logger behavior
- copy over compatibility tests from `cli-table` and add logger coverage for flat and nested procedure outputs