### PR TITLE
Handle Arktype optional object JSON Schema unions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: pnpm build
       - name: write devDependencies to dist # we're only going to install some devDependencies, this helps ensure we get the right ones
         run: cat package.json | jq .devDependencies > dist/devDependencies.json
+      - run: npm pkg delete scripts.prepare
       - run: npm pack --ignore-scripts
       - name: rename tgz
         run: mv $(ls | grep .tgz) pkg.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
       - run: corepack enable
       - run: pnpm install
       - run: pnpm build
-      - run: npm pack
+      - name: write devDependencies to dist # we're only going to install some devDependencies, this helps ensure we get the right ones
+        run: cat package.json | jq .devDependencies > dist/devDependencies.json
+      - run: npm pack --ignore-scripts
       - name: rename tgz
         run: mv $(ls | grep .tgz) pkg.tgz
       - name: arethetypeswrong
         run: npx --yes @arethetypeswrong/cli ./pkg.tgz --profile esm-only
-      - name: write devDependencies to dist # we're only going to install some devDependencies, this helps ensure we get the right ones
-        run: cat package.json | jq .devDependencies > dist/devDependencies.json
       - uses: actions/upload-artifact@v4
         with:
           name: tarball

--- a/src/parse-procedure.ts
+++ b/src/parse-procedure.ts
@@ -132,11 +132,6 @@ function handleMergedSchema(mergedSchema: JSONSchema7): Result<ParsedProcedure> 
   }
 
   if (mergedSchema.anyOf) {
-    const nonOptionalSchemas = mergedSchema.anyOf.filter(sub => !isOptional(sub)).map(toRoughJsonSchema7)
-    if (nonOptionalSchemas.length === 1) {
-      return handleMergedSchema(nonOptionalSchemas[0])
-    }
-
     const allObjects = mergedSchema.anyOf.every(sub => acceptsObject(toRoughJsonSchema7(sub)))
     if (allObjects) {
       return {
@@ -147,6 +142,9 @@ function handleMergedSchema(mergedSchema: JSONSchema7): Result<ParsedProcedure> 
           getPojoInput: argv => argv.options,
         },
       }
+    }
+    if (mergedSchema.anyOf.length === 2 && JSON.stringify(mergedSchema.anyOf[0]) === '{"not":{}}') {
+      return handleMergedSchema(mergedSchema.anyOf[1] as JSONSchema7)
     }
   }
 

--- a/src/parse-procedure.ts
+++ b/src/parse-procedure.ts
@@ -132,6 +132,11 @@ function handleMergedSchema(mergedSchema: JSONSchema7): Result<ParsedProcedure> 
   }
 
   if (mergedSchema.anyOf) {
+    const nonOptionalSchemas = mergedSchema.anyOf.filter(sub => !isOptional(sub)).map(toRoughJsonSchema7)
+    if (nonOptionalSchemas.length === 1) {
+      return handleMergedSchema(nonOptionalSchemas[0])
+    }
+
     const allObjects = mergedSchema.anyOf.every(sub => acceptsObject(toRoughJsonSchema7(sub)))
     if (allObjects) {
       return {
@@ -142,9 +147,6 @@ function handleMergedSchema(mergedSchema: JSONSchema7): Result<ParsedProcedure> 
           getPojoInput: argv => argv.options,
         },
       }
-    }
-    if (mergedSchema.anyOf.length === 2 && JSON.stringify(mergedSchema.anyOf[0]) === '{"not":{}}') {
-      return handleMergedSchema(mergedSchema.anyOf[1] as JSONSchema7)
     }
   }
 

--- a/tasks/arktype-undefined-json-schema.md
+++ b/tasks/arktype-undefined-json-schema.md
@@ -1,0 +1,45 @@
+---
+status: ready
+size: small
+branch: arktype-undefined-json-schema
+---
+
+# Preserve Arktype object flags when input allows undefined
+
+## Status Summary
+
+Spec captured. Implementation has not started yet. The intended fix is to
+reproduce the `type({...}).or('undefined')` Arktype JSON Schema issue through
+the public CLI behavior, then extend the existing Arktype JSON Schema fallback
+only if the current workaround does not already cover it.
+
+## Summary Ask
+
+`trpc-cli` already has a workaround for Arktype's inability to emit JSON Schema
+for the `undefined` unit. Verify whether that workaround handles a command input
+whose schema is an object flag bag unioned with `undefined`, such as
+`type({'port?': 'number'}).or('undefined')`.
+
+The observable behavior should be that CLI flags are still discovered from the
+object branch. A command like `serve --port 56081` should get `{port: 56081}`,
+and `serve --help` should show `--port` rather than falling back to the generic
+`--input [json]` path.
+
+## Assumptions
+
+- Exercise the behavior through the public `createCli`/`run` test helper rather
+  than by asserting on private converter internals.
+- If the current workaround already handles the case, stop after documenting the
+  result rather than forcing a code change.
+- If it fails, keep the fix scoped to Arktype JSON Schema conversion and preserve
+  existing Zod, Valibot, and Effect behavior.
+
+## Checklist
+
+- [ ] Add a failing Arktype CLI test for an optional object input unioned with
+  `undefined`.
+- [ ] Extend the Arktype JSON Schema workaround only as much as needed for that
+  test.
+- [ ] Run the focused Arktype test and the package test suite.
+- [ ] Push the branch and open a pull request if code or tests change.
+

--- a/tasks/arktype-undefined-json-schema.md
+++ b/tasks/arktype-undefined-json-schema.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: implemented
 size: small
 branch: arktype-undefined-json-schema
 ---
@@ -8,10 +8,11 @@ branch: arktype-undefined-json-schema
 
 ## Status Summary
 
-Spec captured. Implementation has not started yet. The intended fix is to
-reproduce the `type({...}).or('undefined')` Arktype JSON Schema issue through
-the public CLI behavior, then extend the existing Arktype JSON Schema fallback
-only if the current workaround does not already cover it.
+Implementation is complete locally and awaiting push/PR.
+The red test reproduced the Arktype optional-object wrapper issue through public
+CLI behavior. The parser now unwraps `anyOf` unions that contain one concrete
+schema plus optional markers, so object options are discovered while unsupported
+record-style schemas still fall back to JSON input with a clearer reason.
 
 ## Summary Ask
 
@@ -36,10 +37,21 @@ and `serve --help` should show `--port` rather than falling back to the generic
 
 ## Checklist
 
-- [ ] Add a failing Arktype CLI test for an optional object input unioned with
-  `undefined`.
-- [ ] Extend the Arktype JSON Schema workaround only as much as needed for that
-  test.
-- [ ] Run the focused Arktype test and the package test suite.
+- [x] Add a failing Arktype CLI test for an optional object input unioned with
+  `undefined`. _Added a public CLI behavior test in `test/arktype.test.ts`; it
+  failed because `--port` was unknown and help fell back to `--input [json]`._
+- [x] Extend the Arktype JSON Schema workaround only as much as needed for that
+  test. _`src/parse-procedure.ts` now unwraps `anyOf` when exactly one branch is
+  non-optional, reusing the existing object/tuple/primitive parsing path._
+- [x] Run the focused Arktype test and the package test suite. _Focused
+  red/green test passes; Arktype/Zod4/Valibot suites, compile, lint, and the
+  full Vitest suite pass._
 - [ ] Push the branch and open a pull request if code or tests change.
 
+## Implementation Notes
+
+- The existing Arktype converter already maps the unsupported `undefined` unit
+  to `{optional: true}` via `toJsonSchema({fallback})`.
+- The missing piece was downstream parsing: object-shaped `anyOf` unions with an
+  optional marker were not reduced to their object branch, so the CLI could not
+  discover flags.

--- a/tasks/complete/2026-05-05-arktype-undefined-json-schema.md
+++ b/tasks/complete/2026-05-05-arktype-undefined-json-schema.md
@@ -1,18 +1,19 @@
 ---
-status: implemented
+status: complete
 size: small
 branch: arktype-undefined-json-schema
+pr: 195
 ---
 
 # Preserve Arktype object flags when input allows undefined
 
 ## Status Summary
 
-Implementation is complete locally and awaiting push/PR.
-The red test reproduced the Arktype optional-object wrapper issue through public
-CLI behavior. The parser now unwraps `anyOf` unions that contain one concrete
-schema plus optional markers, so object options are discovered while unsupported
-record-style schemas still fall back to JSON input with a clearer reason.
+Implementation is complete and published in PR #195. The red test reproduced
+the Arktype optional-object wrapper issue through public CLI behavior. The
+parser now unwraps `anyOf` unions that contain one concrete schema plus optional
+markers, so object options are discovered while unsupported record-style schemas
+still fall back to JSON input with a clearer reason.
 
 ## Summary Ask
 
@@ -46,7 +47,8 @@ and `serve --help` should show `--port` rather than falling back to the generic
 - [x] Run the focused Arktype test and the package test suite. _Focused
   red/green test passes; Arktype/Zod4/Valibot suites, compile, lint, and the
   full Vitest suite pass._
-- [ ] Push the branch and open a pull request if code or tests change.
+- [x] Push the branch and open a pull request if code or tests change. _Opened
+  https://github.com/mmkal/trpc-cli/pull/195._
 
 ## Implementation Notes
 

--- a/tasks/complete/2026-05-05-arktype-undefined-json-schema.md
+++ b/tasks/complete/2026-05-05-arktype-undefined-json-schema.md
@@ -53,7 +53,8 @@ and `serve --help` should show `--port` rather than falling back to the generic
   https://github.com/mmkal/trpc-cli/pull/195._
 - [x] Fix the tarball workflow failure exposed by CI. _Moved
   `dist/devDependencies.json` creation before `npm pack` and packed with
-  `--ignore-scripts`, so the already-built dist is preserved in the tarball._
+  `--ignore-scripts`; CI's npm still ran `prepare`, so the workflow now deletes
+  `scripts.prepare` before packing the already-built dist._
 
 ## Implementation Notes
 

--- a/tasks/complete/2026-05-05-arktype-undefined-json-schema.md
+++ b/tasks/complete/2026-05-05-arktype-undefined-json-schema.md
@@ -13,7 +13,9 @@ Implementation is complete and published in PR #195. The red test reproduced
 the Arktype optional-object wrapper issue through public CLI behavior. The
 parser now unwraps `anyOf` unions that contain one concrete schema plus optional
 markers, so object options are discovered while unsupported record-style schemas
-still fall back to JSON input with a clearer reason.
+still fall back to JSON input with a clearer reason. A small tarball-CI fix was
+also included after the PR run exposed that `dist/devDependencies.json` was
+written after `npm pack`.
 
 ## Summary Ask
 
@@ -49,6 +51,9 @@ and `serve --help` should show `--port` rather than falling back to the generic
   full Vitest suite pass._
 - [x] Push the branch and open a pull request if code or tests change. _Opened
   https://github.com/mmkal/trpc-cli/pull/195._
+- [x] Fix the tarball workflow failure exposed by CI. _Moved
+  `dist/devDependencies.json` creation before `npm pack` and packed with
+  `--ignore-scripts`, so the already-built dist is preserved in the tarball._
 
 ## Implementation Notes
 
@@ -57,3 +62,6 @@ and `serve --help` should show `--port` rather than falling back to the generic
 - The missing piece was downstream parsing: object-shaped `anyOf` unions with an
   optional marker were not reduced to their object branch, so the CLI could not
   discover flags.
+- The tarball matrix was installing `typescript@` because
+  `dist/devDependencies.json` was not inside `pkg.tgz`; npm resolved that to the
+  latest TypeScript 6 prerelease and then failed to install `tsdown`.

--- a/test/arktype.test.ts
+++ b/test/arktype.test.ts
@@ -430,10 +430,8 @@ test('record input', async () => {
 
     Options:
       --input [json]  Input formatted as JSON (procedure's schema couldn't be
-                      converted to CLI arguments: Invalid input type { '$schema':
-                      'https://json-schema.org/draft/2020-12/schema', anyOf: [ {
-                      type: 'object', additionalProperties: [Object] }, { optional:
-                      true } ] }, expected object or tuple.)
+                      converted to CLI arguments: Inputs with additional properties
+                      are not currently supported)
       -h, --help      display help for command
     "
   `)
@@ -584,6 +582,22 @@ test('defaults and negations', async () => {
   )
 })
 // codegen:end
+
+test('optional object input exposes options when unioned with undefined', async () => {
+  const router = t.router({
+    serve: t.procedure
+      .input(
+        type({
+          'port?': 'number.integer > 0',
+          'ui?': 'boolean',
+        }).or('undefined'),
+      )
+      .query(({input}) => JSON.stringify(input || null)),
+  })
+
+  expect(await run(router, ['serve', '--port', '56081'])).toMatchInlineSnapshot(`"{"port":56081}"`)
+  expect(await run(router, ['serve', '--help'])).toContain('--port [number]')
+})
 
 test('arktype issues', () => {
   const toJsonSchema = (schema: type.Any) => {


### PR DESCRIPTION
## Summary

This fixes Arktype inputs like:

```ts
t.procedure
  .input(type({'port?': 'number.integer > 0', 'ui?': 'boolean'}).or('undefined'))
  .query(({input}) => input)
```

Before this PR, Arktype JSON Schema conversion produced an `anyOf` with the object branch plus `{optional: true}`. `trpc-cli` did not unwrap that object branch, so the command fell back to `--input [json]` and flags like `--port` were unknown.

After this PR, parser handling for `anyOf` continues with the single concrete branch when the remaining branches are optional markers. Object options are discovered normally, while unsupported record-style schemas still fall back to JSON input with a clearer reason.

This also fixes the tarball CI workflow exposed by the PR run: `dist/devDependencies.json` was written after `npm pack`, so the tarball tests installed `typescript@` and resolved the latest TypeScript 6 prerelease. The workflow now writes that metadata before packing, removes the temporary `prepare` script in CI, and packs the already-built `dist`.

## Validation

- Red test: `pnpm test --run test/arktype.test.ts -t "optional object input exposes options when unioned with undefined"`
- Green focused test: `pnpm test --run test/arktype.test.ts -t "optional object input exposes options when unioned with undefined"`
- `pnpm test --run test/arktype.test.ts test/zod4.test.ts test/valibot.test.ts`
- `pnpm compile`
- `pnpm lint`
- `pnpm test`
- Local tarball check: `npm pack --ignore-scripts` includes `package/dist/devDependencies.json`