### PR TITLE
Add agent environment detection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,18 +1222,20 @@ You can enable prompts for positional arguments and options simply by installing
 npm install @inquirer/prompts
 ```
 
-The pass it in when running your CLI:
+Then pass it in when running your CLI:
 
 ```ts
 import * as prompts from '@inquirer/prompts' // or import * as prompts from 'enquirer', or import * as prompts from 'prompts'
-import {createCli} from 'trpc-cli'
+import {createCli, isAgent} from 'trpc-cli'
 
 const cli = createCli({router: myRouter})
 
-cli.run({prompts})
+await cli.run({
+  prompts: isAgent() ? null : prompts,
+})
 ```
 
-The user will then be asked to input any missing arguments or options. Booleans, numbers, enums etc. will get appropriate user-friendly prompts, along with input validation.
+Human users will then be asked to input any missing arguments or options, while known coding-agent environments like Claude Code, Codex, and opencode skip prompts. Booleans, numbers, enums etc. will get appropriate user-friendly prompts, along with input validation.
 
 You can also pass in a custom "Prompter". This in theory enables you to prompt in *any way* you'd like. You will be passed a `Command` instance, and then must define `input`, `select`, `confirm` and `checkbox` prompts. You can also define `setup` and `teardown` functions which run before and after the individual prompts for arguments and options. This could be used to render an all-in-one form filling in inputs. See [the tests for an example](./test/prompts.test.ts).
 
@@ -1327,7 +1329,7 @@ Note - in the above example `src/your-router.ts` will be imported, and then its 
 ### API docs
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/index.ts, export: createCli} -->
-#### [createCli](./src/index.ts#L123)
+#### [createCli](./src/index.ts#L124)
 
 Run a trpc router as a CLI.
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,0 +1,15 @@
+export type AgentEnvironment = Record<string, string | undefined>
+
+export function isAgent(env: AgentEnvironment = process.env): boolean {
+  if (isEnabled(env.CLAUDECODE)) return true
+  if (isEnabled(env.CODEX_CI)) return true
+  if (isEnabled(env.CODEX_THREAD_ID)) return true
+  if (isEnabled(env.OPENCODE_RUN_ID) && env.OPENCODE_PROCESS_ROLE === 'worker') return true
+  return false
+}
+
+function isEnabled(value: string | undefined) {
+  if (!value?.trim()) return false
+  const normalized = value.trim().toLowerCase()
+  return normalized !== '0' && normalized !== 'false'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ declare module 'zod' {
 }
 
 export * from './types.js'
+export {isAgent, type AgentEnvironment} from './agent.js'
 
 /** @deprecated use `import * as trpcServer from '@trpc/server'` instead */
 export const trpcServer = "@deprecated use `import * as trpcServer from '@trpc/server'` instead"

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,7 +181,7 @@ export type TrpcCliRunParams = {
   argv?: string[]
   logger?: Logger
   completion?: OmeletteInstanceLike | (() => Promise<OmeletteInstanceLike>)
-  prompts?: Promptable
+  prompts?: Promptable | null
   /** Format an error thrown by the root procedure before logging to `logger.error` */
   formatError?: (error: unknown) => string
   process?: {

--- a/tasks/agent-detection.md
+++ b/tasks/agent-detection.md
@@ -1,0 +1,59 @@
+---
+status: ready
+size: small
+branch: agent-detection
+---
+
+# Add an agent-environment detection helper
+
+## Status Summary
+
+Spec is ready for a small implementation pass. The intended surface is a pure
+exported helper with docs and tests; no CLI behavior should change unless users
+opt into it by calling the helper.
+
+## Summary Ask
+
+Add a helper function that detects whether the current process appears to be
+running inside a coding-agent environment such as Claude Code, Codex, or
+opencode.
+
+The primary motivating usage should be documented as:
+
+```ts
+await cli.run({
+  prompts: isAgent() ? null : prompts,
+})
+```
+
+That lets library consumers keep interactive prompts for humans while avoiding
+prompt hangs or unhelpful interaction loops when a coding agent invokes the CLI.
+
+## Guesses and Assumptions
+
+- The helper should default to `process.env`, but accept an explicit env object
+  in tests and for advanced embedding.
+- The helper should be conservative: return true only for known signals from
+  common coding agents, not for generic CI or non-interactive terminals.
+- The helper should be exported from `src/index.ts` and documented in the README.
+- The exact env-var list is allowed to evolve, but this first pass should cover
+  Claude, Codex, and opencode without taking a dependency.
+- If an agent's env vars are uncertain, document that uncertainty in code or test
+  names rather than pretending the detection is exhaustive.
+
+## Checklist
+
+- [ ] Add a pure `isAgent` helper with an injectable environment object.
+- [ ] Cover Claude, Codex, and opencode-style env vars with focused tests.
+- [ ] Export the helper from the public package entrypoint.
+- [ ] Document the `prompts: isAgent() ? null : prompts` use case.
+- [ ] Run the focused tests plus compile or the full suite if the change touches
+  shared types.
+
+## Out of Scope
+
+- Do not automatically disable prompts inside `createCli` or `run`.
+- Do not detect generic CI, SSH, TTY absence, or editor terminals as coding
+  agents.
+- Do not add runtime dependencies.
+

--- a/tasks/complete/2026-05-05-agent-detection.md
+++ b/tasks/complete/2026-05-05-agent-detection.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: done
 size: small
 branch: agent-detection
 ---
@@ -8,9 +8,9 @@ branch: agent-detection
 
 ## Status Summary
 
-Spec is ready for a small implementation pass. The intended surface is a pure
-exported helper with docs and tests; no CLI behavior should change unless users
-opt into it by calling the helper.
+Done. Added a pure exported `isAgent` helper, covered Claude Code/Codex/opencode
+signals with tests, documented agent-aware prompt disabling, and verified with
+focused tests, compile, and lint. No missing implementation pieces remain.
 
 ## Summary Ask
 
@@ -43,12 +43,12 @@ prompt hangs or unhelpful interaction loops when a coding agent invokes the CLI.
 
 ## Checklist
 
-- [ ] Add a pure `isAgent` helper with an injectable environment object.
-- [ ] Cover Claude, Codex, and opencode-style env vars with focused tests.
-- [ ] Export the helper from the public package entrypoint.
-- [ ] Document the `prompts: isAgent() ? null : prompts` use case.
-- [ ] Run the focused tests plus compile or the full suite if the change touches
-  shared types.
+- [x] Add a pure `isAgent` helper with an injectable environment object. _Implemented in `src/agent.ts` with a `process.env` default and injectable `AgentEnvironment`._
+- [x] Cover Claude, Codex, and opencode-style env vars with focused tests. _Added `test/agent.test.ts` for `CLAUDECODE`, Codex `CODEX_*`, opencode worker env, and non-agent false positives._
+- [x] Export the helper from the public package entrypoint. _Exported `isAgent` and `AgentEnvironment` from `src/index.ts`._
+- [x] Document the `prompts: isAgent() ? null : prompts` use case. _Updated the README input prompt example to disable prompts only for detected coding agents._
+- [x] Run the focused tests plus compile or the full suite if the change touches
+  shared types. _Ran focused Vitest files, `pnpm compile`, and `pnpm lint`; all passed._
 
 ## Out of Scope
 
@@ -57,3 +57,11 @@ prompt hangs or unhelpful interaction loops when a coding agent invokes the CLI.
   agents.
 - Do not add runtime dependencies.
 
+## Implementation Notes
+
+- 2026-05-05: `TrpcCliRunParams.prompts` now accepts `null` so the documented
+  agent-aware prompt disabling example type-checks while preserving existing
+  runtime behavior.
+- 2026-05-05: `pnpm install --frozen-lockfile` was needed because the worktree
+  had no `node_modules`; it used the existing lockfile and made no dependency
+  changes.

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1,0 +1,40 @@
+import {expect, test} from 'vitest'
+import {isAgent} from '../src/index.js'
+
+test('detects Claude Code command environments', () => {
+  expect(isAgent({CLAUDECODE: '1'})).toBe(true)
+})
+
+test('detects Codex command environments', () => {
+  expect(isAgent({CODEX_CI: '1'})).toBe(true)
+  expect(isAgent({CODEX_THREAD_ID: '019df84d-65de-7ff3-851c-9e283198136c'})).toBe(true)
+})
+
+test('detects opencode worker shell environments', () => {
+  expect(
+    isAgent({
+      OPENCODE_RUN_ID: '5e29ec56-6c7f-4730-a281-091f4dd240fe',
+      OPENCODE_PROCESS_ROLE: 'worker',
+    }),
+  ).toBe(true)
+})
+
+test('ignores generic automation and configuration variables', () => {
+  expect(isAgent({CI: 'true'})).toBe(false)
+  expect(isAgent({OPENAI_API_KEY: 'test-key'})).toBe(false)
+  expect(isAgent({CLAUDE_CODE_ENABLE_TELEMETRY: '1'})).toBe(false)
+  expect(isAgent({OPENCODE_INSTALL_DIR: '/usr/local/bin'})).toBe(false)
+  expect(
+    isAgent({
+      OPENCODE_RUN_ID: '5e29ec56-6c7f-4730-a281-091f4dd240fe',
+      OPENCODE_PROCESS_ROLE: 'main',
+    }),
+  ).toBe(false)
+})
+
+test('ignores disabled or empty agent flags', () => {
+  expect(isAgent({CLAUDECODE: '0'})).toBe(false)
+  expect(isAgent({CODEX_CI: 'false'})).toBe(false)
+  expect(isAgent({CODEX_THREAD_ID: ''})).toBe(false)
+  expect(isAgent({OPENCODE_RUN_ID: ' ', OPENCODE_PROCESS_ROLE: 'worker'})).toBe(false)
+})

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import {test, expectTypeOf} from 'vitest'
 import {z} from 'zod/v4'
-import {EnquirerLike, InquirerPromptsLike, Promptable} from '../src/index.js'
+import {EnquirerLike, InquirerPromptsLike, isAgent, Promptable} from '../src/index.js'
+import type {TrpcCliRunParams} from '../src/index.js'
 
 test('prompt types', async () => {
   expectTypeOf<typeof import('@inquirer/prompts')>().toExtend<InquirerPromptsLike>()
@@ -9,6 +10,10 @@ test('prompt types', async () => {
 
   expectTypeOf<typeof import('@inquirer/prompts')>().toExtend<Promptable>()
   expectTypeOf<typeof import('enquirer')>().toExtend<Promptable>()
+})
+
+test('agent-aware prompt disabling type', async () => {
+  expectTypeOf({prompts: isAgent({}) ? null : ({} as Promptable)}).toMatchTypeOf<TrpcCliRunParams>()
 })
 
 test('zod meta', async () => {


### PR DESCRIPTION
## Summary

Adds a pure `isAgent(env = process.env)` helper for consumers that want to skip interactive prompts when a known coding agent invokes their CLI.

The first signal set is intentionally conservative:

- Claude Code command shells via `CLAUDECODE`
- Codex command shells via `CODEX_CI` or `CODEX_THREAD_ID`
- opencode worker shell environments via `OPENCODE_RUN_ID` plus `OPENCODE_PROCESS_ROLE=worker`

The prompt opt-out pattern now type-checks because `run` accepts `prompts: null` as an explicit disabled value:

```ts
import * as prompts from '@inquirer/prompts'
import {createCli, isAgent} from 'trpc-cli'

const cli = createCli({router})

await cli.run({
  prompts: isAgent() ? null : prompts,
})
```

Generic automation and configuration variables such as `CI`, provider API keys, Claude Code config flags, and opencode install vars are not treated as agent signals.

## Tests

- `pnpm exec vitest run test/agent.test.ts test/types.test.ts`
- `pnpm compile`
- `pnpm lint`

## Notes

No runtime dependencies added.
