### PR TITLE
Reapply TypeBox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 trpc-cli transforms a [tRPC](https://trpc.io) (or [oRPC](#orpc)) router into a professional-grade CLI with zero boilerplate. Get end-to-end type safety, input validation, auto-generated help documentation, and command completion for free.
 
 - ✅ Get all of trpc's type safety and DX building a CLI
-- ✅ Automatic positional arguments and options via zod input types (or arktype, or valibot)
+- ✅ Automatic positional arguments and options via zod input types (or arktype, valibot, effect, or typebox)
 - ✅ Easily add subcommands via nested trpc routers
 - ✅ Rich helptext out of the box
 - ✅ Exactly one dependency: [`commander`](https://npmjs.com/package/commander)
@@ -37,6 +37,7 @@ trpc-cli transforms a [tRPC](https://trpc.io) (or [oRPC](#orpc)) router into a p
    - [arktype](#arktype)
    - [valibot](#valibot)
    - [effect](#effect)
+   - [typebox](#typebox)
 - [Examples](#examples)
    - [Calculator Example](#calculator-example)
    - [Migrator Example](#migrator-example)
@@ -524,6 +525,29 @@ const router = t.router({
 })
 
 const cli = createCli({router, trpcServer: import('@trpc/server')})
+
+cli.run() // e.g. `mycli add 1 2`
+```
+
+### typebox
+
+TypeBox does not add Standard Schema directly to its schema objects. trpc-cli provides a small adapter based on TypeBox's [reference adapter](https://github.com/sinclairzx81/typebox/tree/main/example/standard), so wrap the TypeBox schema before passing it into `.input(...)`.
+
+trpc-cli reads the JSON Schema from `~standard.jsonSchema.input({target: 'draft-07'})`, so TypeBox schemas do not need a separate conversion dependency once they are wrapped.
+
+```ts
+import {type TrpcCliMeta, typeboxToStandardSchema} from 'trpc-cli'
+import Type from 'typebox'
+
+const t = initTRPC.meta<TrpcCliMeta>().create()
+
+const router = t.router({
+  add: t.procedure
+    .input(typeboxToStandardSchema(Type.Tuple([Type.Number(), Type.Number()])))
+    .query(({input}) => input[0] + input[1]),
+})
+
+const cli = createCli({router})
 
 cli.run() // e.g. `mycli add 1 2`
 ```
@@ -1327,7 +1351,7 @@ Note - in the above example `src/your-router.ts` will be imported, and then its 
 ### API docs
 
 <!-- codegen:start {preset: markdownFromJsdoc, source: src/index.ts, export: createCli} -->
-#### [createCli](./src/index.ts#L123)
+#### [createCli](./src/index.ts#L129)
 
 Run a trpc router as a CLI.
 
@@ -1373,7 +1397,7 @@ The only dependency is [`commander`](https://npmjs.com/package/commander), for p
 
 ![Dependency tree from npmgraph](./docs/deps.png)
 
-`@trpc/server` and `@orpc/server` are peerDependencies, but one of the two must be installed. Similarly one of `zod`, `valibot`, `arktype` or `effect` will likely be needed for input validation. The code from [zod-to-json-schema](https://npmjs.com/package/zod-to-json-schema) has been copied more or less as-is to this repo in order to support json schema conversion for old versions of zod.
+`@trpc/server` and `@orpc/server` are peerDependencies, but one of the two must be installed. Similarly one of `zod`, `valibot`, `arktype`, `effect` or `typebox` will likely be needed for input validation. The code from [zod-to-json-schema](https://npmjs.com/package/zod-to-json-schema) has been copied more or less as-is to this repo in order to support json schema conversion for old versions of zod.
 
 ### Testing
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@trpc/server": "^10.45.2 || ^11.0.1",
     "@valibot/to-json-schema": "^1.1.0",
     "effect": "^3.14.2 || ^4.0.0",
+    "typebox": "^1.1.37",
     "valibot": "^1.1.0",
     "zod": "^3.24.0 || ^4.0.0"
   },
@@ -58,6 +59,9 @@
       "optional": true
     },
     "effect": {
+      "optional": true
+    },
+    "typebox": {
       "optional": true
     },
     "valibot": {
@@ -98,6 +102,7 @@
     "trpcserver10": "npm:@trpc/server@^10.45.2",
     "trpcserver11": "npm:@trpc/server@^11.1.1",
     "tsx": "4.20.3",
+    "typebox": "^1.1.37",
     "typescript": "5.8.3",
     "valibot": "1.2.0",
     "vitest": "3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       tsx:
         specifier: 4.20.3
         version: 4.20.3
+      typebox:
+        specifier: ^1.1.37
+        version: 1.1.37
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -3790,6 +3793,9 @@ packages:
   type-fest@5.1.0:
     resolution: {integrity: sha512-wQ531tuWvB6oK+pchHIu5lHe5f5wpSCqB8Kf4dWQRbOYc9HTge7JL0G4Qd44bh6QuJCccIzL3bugb8GI0MwHrg==}
     engines: {node: '>=20'}
+
+  typebox@1.1.37:
+    resolution: {integrity: sha512-jb7jp6KvOvvy5sd+11AfJ0/e0F0AS9RcOXd55oGi2ZnRHIGmFvrTaNF+ZidRmGBmmNTkM5KKl0Z37KzxJ+owEQ==}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -8142,6 +8148,8 @@ snapshots:
   type-fest@5.1.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  typebox@1.1.37: {}
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,12 @@ declare module 'zod' {
 }
 
 export * from './types.js'
+export {typeboxToStandardSchema} from './typebox.js'
+export type {
+  TypeBoxStandardJsonSchemaConverter,
+  TypeBoxStandardJsonSchemaOptions,
+  TypeBoxStandardSchema,
+} from './typebox.js'
 
 /** @deprecated use `import * as trpcServer from '@trpc/server'` instead */
 export const trpcServer = "@deprecated use `import * as trpcServer from '@trpc/server'` instead"

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -259,6 +259,13 @@ const getModule = <T>(moduleOrError: T | string): T => {
   return moduleOrError
 }
 
+type StandardJsonSchemaOptions = {
+  target: 'draft-2020-12' | 'draft-07' | 'openapi-3.0' | (string & {})
+  libraryOptions?: Record<string, unknown>
+}
+
+type StandardJsonSchemaConverter = (options: StandardJsonSchemaOptions) => Record<string, unknown>
+
 /**
  * Attempts to convert a trpc procedure input to JSON schema.
  * Uses @see jsonSchemaConverters to convert the input to JSON schema.
@@ -276,6 +283,12 @@ export function toJsonSchema(input: unknown, dependencies: Dependencies): Result
     // fallback - no vendor-specific converter, but there may be a toJsonSchema method on the input
     if (typeof (input as Record<string, unknown>)?.toJsonSchema === 'function') {
       return {success: true, value: (input as {toJsonSchema: () => JSONSchema7}).toJsonSchema()}
+    }
+
+    const standardJsonSchemaConverter = getStandardJsonSchemaConverter(input)
+    if (standardJsonSchemaConverter) {
+      // Standard Schema adapters are expected to honor this target; downstream CLI parsing expects draft-07 shape.
+      return {success: true, value: standardJsonSchemaConverter({target: 'draft-07'}) as JSONSchema7}
     }
 
     return {success: false, error: `Schema not convertible to JSON schema`}
@@ -361,9 +374,18 @@ function getVendor(schema: unknown) {
   return (schema as {['~standard']?: {vendor?: string}})?.['~standard']?.vendor ?? null
 }
 
+function getStandardJsonSchemaConverter(schema: unknown): StandardJsonSchemaConverter | null {
+  const jsonSchema = (schema as {['~standard']?: {jsonSchema?: Record<string, unknown>}})?.['~standard']?.jsonSchema
+  if (!jsonSchema) return null
+  if (typeof jsonSchema.input === 'function') return jsonSchema.input as StandardJsonSchemaConverter
+  if (typeof jsonSchema.output === 'function') return jsonSchema.output as StandardJsonSchemaConverter
+  return null
+}
+
 const jsonSchemaVendorNames = new Set(Object.keys(getJsonSchemaConverters({})))
 export function looksJsonSchemaable(value: unknown) {
   if (typeof (value as Record<string, unknown>)?.toJsonSchema === 'function') return true
+  if (getStandardJsonSchemaConverter(value)) return true
   const vendor = getVendor(value)
   return !!vendor && jsonSchemaVendorNames.has(vendor)
 }

--- a/src/parse-procedure.ts
+++ b/src/parse-procedure.ts
@@ -170,11 +170,17 @@ function handleMergedSchema(mergedSchema: JSONSchema7): Result<ParsedProcedure> 
 // zod-to-json-schema turns `z.string().optional()` into `{"anyOf":[{"not":{}},{"type":"string"}]}`
 export function isOptional(schema: JSONSchema7Definition) {
   if (schema && typeof schema === 'object' && 'optional' in schema) return schema.optional === true
+  if (hasUndefinedType(schema)) return true
   if (schemaDefPropValue(schema, 'not') && JSON.stringify(schema) === '{"not":{}}') return true
   const anyOf = schemaDefPropValue(schema, 'anyOf')
   if (anyOf?.some(sub => isOptional(sub))) return true
   if (schemaDefPropValue(schema, 'default') !== undefined) return true
   return false
+}
+
+function hasUndefinedType(schema: JSONSchema7Definition) {
+  const type = schema && typeof schema === 'object' ? (schema as {type?: unknown}).type : undefined
+  return type === 'undefined' || (Array.isArray(type) && type.includes('undefined'))
 }
 
 function parsePrimitiveInput(schema: JSONSchema7): Result<ParsedProcedure> {

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -1,0 +1,131 @@
+/*
+ * TypeBox Standard Schema adapter.
+ *
+ * Attribution: adapted from TypeBox's MIT-licensed Standard Schema reference adapter:
+ * https://github.com/sinclairzx81/typebox/tree/main/example/standard
+ * Copyright (c) 2017-2026 Haydn Paterson
+ *
+ * Modifications: reuse trpc-cli's existing StandardSchemaV1 contract, keep only the
+ * TypeBox adapter surface trpc-cli needs, and expose a trpc-cli-specific factory name.
+ */
+
+import {createRequire} from 'module'
+import type {StandardSchemaV1 as StandardSchemaV1Contract} from './standard-schema/contract.js'
+
+const require = createRequire(import.meta.url)
+
+type TypeBoxValidationError = {
+  instancePath: string
+  message: string
+}
+
+type TypeBoxValidator = {
+  Check: (value: unknown) => boolean
+  Errors: (value: unknown) => [boolean, TypeBoxValidationError[]]
+  Schema: () => Record<string, unknown>
+}
+
+type TypeBoxSchemaModule = {
+  Validator: new (context: Record<PropertyKey, unknown>, schema: TypeBoxSchemaLike) => TypeBoxValidator
+}
+
+type Simplify<T> = {[K in keyof T]: T[K]} & {}
+
+export type TypeBoxSchemaLike = object
+
+export type TypeBoxStatic<Schema> = Schema extends {const: infer Value}
+  ? Value
+  : Schema extends {anyOf: infer Variants extends readonly unknown[]}
+    ? TypeBoxStatic<Variants[number]>
+    : Schema extends {type: 'string'}
+      ? string
+      : Schema extends {type: 'number' | 'integer'}
+        ? number
+        : Schema extends {type: 'boolean'}
+          ? boolean
+          : Schema extends {type: 'undefined'}
+            ? undefined
+            : Schema extends {type: 'null'}
+              ? null
+              : Schema extends {type: 'array'; items: infer Items}
+                ? Items extends readonly unknown[]
+                  ? {[Index in keyof Items]: TypeBoxStatic<Items[Index]>}
+                  : TypeBoxStatic<Items>[]
+                : Schema extends {type: 'object'; properties: infer Properties extends Record<string, unknown>}
+                  ? TypeBoxObjectStatic<
+                      Properties,
+                      Schema extends {required: readonly (infer Required)[]} ? Extract<Required, string> : never
+                    >
+                  : unknown
+
+type TypeBoxObjectStatic<Properties extends Record<string, unknown>, RequiredKeys extends string> = Simplify<
+  {
+    [Key in Extract<keyof Properties, RequiredKeys>]: TypeBoxStatic<Properties[Key]>
+  } & {
+    [Key in Exclude<keyof Properties, RequiredKeys>]?: TypeBoxStatic<Properties[Key]>
+  }
+>
+
+export type TypeBoxStandardJsonSchemaOptions = {
+  target: 'draft-2020-12' | 'draft-07' | 'openapi-3.0' | (string & {})
+  libraryOptions?: Record<string, unknown>
+}
+
+export type TypeBoxStandardJsonSchemaConverter = {
+  input: (options: TypeBoxStandardJsonSchemaOptions) => Record<string, unknown>
+  output: (options: TypeBoxStandardJsonSchemaOptions) => Record<string, unknown>
+}
+
+export type TypeBoxStandardSchema<Schema extends TypeBoxSchemaLike> = StandardSchemaV1Contract<
+  TypeBoxStatic<Schema>
+> & {
+  '~standard': StandardSchemaV1Contract.Props<TypeBoxStatic<Schema>> & {
+    jsonSchema: TypeBoxStandardJsonSchemaConverter
+  }
+}
+
+export function typeboxToStandardSchema<Schema extends TypeBoxSchemaLike>(
+  schema: Schema,
+): TypeBoxStandardSchema<Schema> {
+  const {Validator} = getTypeBoxSchemaModule()
+  const validator = new Validator({}, schema)
+  const jsonSchema = {
+    input: () => validator.Schema(),
+    output: () => validator.Schema(),
+  }
+
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'typebox',
+      validate(value) {
+        if (validator.Check(value)) return {value}
+        const [_result, errors] = validator.Errors(value)
+        return {
+          issues: errors.map(error => ({
+            path: pathSegments(error),
+            message: error.message,
+          })),
+        }
+      },
+      jsonSchema,
+    },
+  } as TypeBoxStandardSchema<Schema>
+}
+
+function getTypeBoxSchemaModule(): TypeBoxSchemaModule {
+  try {
+    return require('typebox/schema') as TypeBoxSchemaModule
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`typebox must be installed to use typeboxToStandardSchema. Error loading: ${message}`)
+  }
+}
+
+function pathSegments(error: TypeBoxValidationError) {
+  if (!error.instancePath) return []
+  return error.instancePath
+    .slice(1)
+    .split('/')
+    .map(segment => segment.replaceAll('~1', '/').replaceAll('~0', '~'))
+}

--- a/tasks/complete/2026-05-05-typebox-support.md
+++ b/tasks/complete/2026-05-05-typebox-support.md
@@ -1,0 +1,57 @@
+---
+status: complete
+size: medium
+---
+
+# First-class TypeBox support
+
+## Status Summary
+
+Done. TypeBox Standard Schema wrappers map to CLI arguments through `~standard.jsonSchema`, trpc-cli owns the adapter surface via the root `trpc-cli` export, README usage points at that adapter, and the full build/test suite passes.
+
+## Goal
+
+Make TypeBox feel like a first-class validation library for trpc-cli procedure inputs.
+
+Users should be able to define a TypeBox schema, wrap it in the TypeBox Standard Schema adapter shape, pass that wrapped schema into `.input(...)`, and have trpc-cli:
+
+- validate command input through the Standard Schema interface
+- derive CLI arguments/options from the underlying TypeBox JSON Schema
+- preserve useful behavior for primitives, objects, enums, tuples, arrays, optional fields, and merged inputs
+
+## Context
+
+TypeBox does not appear to expose Standard Schema directly from the package API. The upstream TypeBox example at `https://github.com/sinclairzx81/typebox/tree/main/example/standard` shows a reference adapter that wraps JSON Schema or TypeBox schemas and attaches `~standard`.
+
+That adapter also exposes `~standard.jsonSchema.input()` and `~standard.jsonSchema.output()`, which should give trpc-cli a simple conversion path without requiring a separate TypeBox-to-JSON-Schema implementation. Since TypeBox schemas are already JSON Schema-ish objects, the conversion may be little more than calling `jsonSchema.input({target: 'draft-07'})` or returning the schema itself.
+
+## Assumptions
+
+- The public TypeBox package does not currently provide a stable import like `typebox/standard`.
+- trpc-cli does not need to vendor TypeBox's adapter as public API; tests can define a tiny local wrapper if that matches how TypeBox users are expected to integrate today.
+- TypeBox should be added as an optional peer dependency and dev dependency only if the test needs the real package.
+- Product support should be based on Standard Schema vendor/jsonSchema detection rather than hard-coding only the local test wrapper.
+
+## Checklist
+
+- [x] Add a TypeBox integration test file that passes TypeBox-backed Standard Schema values into `.input(...)`. _Implemented in `test/typebox.test.ts` with a local wrapper matching the upstream TypeBox adapter shape._
+- [x] Cover at least primitive, enum, object/options, optional option, tuple, array, and merged object inputs. _Covered in `test/typebox.test.ts`; top-level optional uses TypeBox's valid `Type.Union([Type.String(), Type.Undefined()])` shape._
+- [x] Add or adjust JSON Schema conversion so Standard Schema values with `~standard.jsonSchema` are accepted. _Added generic `~standard.jsonSchema.input({target: 'draft-07'})` support in `src/json-schema.ts`._
+- [x] Add TypeBox as an optional peer/dev dependency if the real package is required for tests. _Added `typebox` as a dev dependency for integration coverage and as an optional peer for the root adapter export._
+- [x] Export a TypeBox adapter from trpc-cli. _Added `src/typebox.ts` and re-exported `typeboxToStandardSchema` from `src/index.ts`; tests import it from the root library source instead of defining a local wrapper._
+- [x] Run the focused TypeBox tests. _`pnpm vitest run test/typebox.test.ts` passes._
+- [x] Run the relevant existing validation-library tests. _`pnpm vitest run test/typebox.test.ts test/effect.test.ts test/arktype.test.ts test/valibot.test.ts test/zod3.test.ts test/zod4.test.ts` passes; full `pnpm test` also passes._
+- [x] Verify package export behavior. _`pnpm build` emits the root declaration with `typeboxToStandardSchema`; Node self-reference import from `trpc-cli` works without adding a package `exports` map._
+- [x] Update README or exported docs only if there is a useful user-facing TypeBox note to preserve. _Added a TypeBox validator section documenting the wrapper requirement and Standard JSON Schema conversion path._
+
+## Implementation Notes
+
+- 2026-05-05: Created task from the user request before implementation. The upstream TypeBox example is an adapter around TypeBox/JSON Schema, not a currently documented public import.
+- 2026-05-05: Added a failing TypeBox test first. The failure showed trpc-cli falling back to `--input [json]` because TypeBox wrappers were not detected as JSON-schemaable.
+- 2026-05-05: Added generic Standard JSON Schema support by detecting `~standard.jsonSchema` on Standard Schema inputs. TypeBox does not need a TypeBox-specific converter because its adapter returns the underlying schema.
+- 2026-05-05: Verified with focused TypeBox tests, validator matrix tests, `pnpm compile`, `pnpm lint`, and full `pnpm test`.
+- 2026-05-05: Follow-up from review: moved the TypeBox adapter into `src/typebox.ts` and exposed it from the root `trpc-cli` API, because first-class support should not require users to copy a local adapter.
+- 2026-05-05: Re-verified after adding the export with `pnpm vitest run test/typebox.test.ts`, `pnpm compile`, `pnpm lint`, `pnpm build`, a Node self-reference import from `trpc-cli`, validator matrix tests, and full `pnpm test`.
+- 2026-05-05: Renamed the public adapter helper to `typeboxToStandardSchema` to make the conversion explicit.
+- 2026-05-12: Removed the package `exports` map to avoid breaking documented deep imports like `trpc-cli/dist/proxify.js`; the root export lazy-loads TypeBox only when `typeboxToStandardSchema` is called.
+- 2026-05-12: Follow-up from Pull Frog review: removed the untested TypeBox `~optional` positional branch because `Type.Optional(...)` only works as an object-property modifier in TypeBox validation, and added a comment documenting the draft-07 expectation for Standard JSON Schema converters.

--- a/test/typebox.test.ts
+++ b/test/typebox.test.ts
@@ -1,0 +1,203 @@
+import {initTRPC} from 'trpcserver11'
+import Type from 'typebox'
+import {expect, test} from 'vitest'
+import {TrpcCliMeta, typeboxToStandardSchema} from '../src/index.js'
+import {run, snapshotSerializer} from './test-run.js'
+
+expect.addSnapshotSerializer(snapshotSerializer)
+
+const t = initTRPC.meta<TrpcCliMeta>().create()
+
+test('merging input types', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Object({bar: Type.String()})))
+      .input(typeboxToStandardSchema(Type.Object({baz: Type.Number()})))
+      .input(typeboxToStandardSchema(Type.Object({qux: Type.Boolean()})))
+      .query(({input}) => JSON.stringify({bar: input.bar, baz: input.baz, qux: input.qux})),
+  })
+
+  expect(await run(router, ['foo', '--bar', 'hello', '--baz', '42', '--qux'])).toMatchInlineSnapshot(
+    `"{"bar":"hello","baz":42,"qux":true}"`,
+  )
+})
+
+test('string input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.String())) //
+      .query(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['foo', 'hello'])).toMatchInlineSnapshot(`""hello""`)
+})
+
+test('enum input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Union([Type.Literal('aa'), Type.Literal('bb')]))) //
+      .query(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['foo', 'aa'])).toMatchInlineSnapshot(`""aa""`)
+  await expect(run(router, ['foo', 'cc'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CliValidationError: ✖ must be equal to constant
+    ✖ must be equal to constant
+    ✖ must match a schema in anyOf
+  `)
+})
+
+test('number input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Number())) //
+      .query(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['foo', '1'])).toMatchInlineSnapshot(`"1"`)
+  await expect(run(router, ['foo', 'a'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: command-argument value 'a' is invalid for argument 'number'. Invalid number: a
+  `)
+})
+
+test('boolean input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Boolean())) //
+      .query(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['foo', 'true'])).toMatchInlineSnapshot(`"true"`)
+  expect(await run(router, ['foo', 'false'])).toMatchInlineSnapshot(`"false"`)
+  await expect(run(router, ['foo', 'a'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CliValidationError: ✖ must be boolean
+  `)
+})
+
+test('literal input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Literal(2))) //
+      .query(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['foo', '2'])).toMatchInlineSnapshot(`"2"`)
+  await expect(run(router, ['foo', '3'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CliValidationError: ✖ must be equal to constant
+  `)
+})
+
+test('optional input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Union([Type.String(), Type.Undefined()]))) //
+      .query(({input}) => JSON.stringify(input || null)),
+  })
+
+  expect(await run(router, ['foo', 'a'])).toMatchInlineSnapshot(`""a""`)
+  expect(await run(router, ['foo'])).toMatchInlineSnapshot(`"null"`)
+})
+
+test('union input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Union([Type.Number(), Type.String()]))) //
+      .query(({input}) => JSON.stringify(input || null)),
+  })
+
+  expect(await run(router, ['foo', 'a'])).toMatchInlineSnapshot(`""a""`)
+  expect(await run(router, ['foo', '1'])).toMatchInlineSnapshot(`"1"`)
+})
+
+test('array input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Array(Type.String()))) //
+      .query(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['foo', 'src/index.ts', 'README.md'])).toMatchInlineSnapshot(
+    `"["src/index.ts","README.md"]"`,
+  )
+})
+
+test('tuple input', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(typeboxToStandardSchema(Type.Tuple([Type.String(), Type.Number()]))) //
+      .query(({input}) => JSON.stringify(input || null)),
+  })
+
+  expect(await run(router, ['foo', 'hello', '123'])).toMatchInlineSnapshot(`"["hello",123]"`)
+  await expect(run(router, ['foo', 'hello', 'not a number!'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: command-argument value 'not a number!' is invalid for argument 'parameter_2'. Invalid number: not a number!
+  `)
+})
+
+test('tuple input with flags', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(
+        typeboxToStandardSchema(
+          Type.Tuple([
+            Type.String(),
+            Type.Number(),
+            Type.Object({foo: Type.String()}), //
+          ]),
+        ),
+      )
+      .query(({input}) => JSON.stringify(input || null)),
+  })
+
+  expect(await run(router, ['foo', 'hello', '123', '--foo', 'bar'])).toMatchInlineSnapshot(
+    `"["hello",123,{"foo":"bar"}]"`,
+  )
+  await expect(run(router, ['foo', 'hello', '123'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: required option '--foo <string>' not specified
+  `)
+  await expect(run(router, ['foo', 'hello', 'not a number!', '--foo', 'bar'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: command-argument value 'not a number!' is invalid for argument 'parameter_2'. Invalid number: not a number!
+  `)
+  await expect(run(router, ['foo', 'hello', 'not a number!'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: required option '--foo <string>' not specified
+  `)
+})
+
+test('object options', async () => {
+  const router = t.router({
+    foo: t.procedure
+      .input(
+        typeboxToStandardSchema(
+          Type.Object({
+            userId: Type.Number(),
+            name: Type.String(),
+            admin: Type.Optional(Type.Boolean()),
+          }),
+        ),
+      )
+      .query(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['foo', '--user-id', '123', '--name', 'bob'])).toMatchInlineSnapshot(
+    `"{"userId":123,"name":"bob"}"`,
+  )
+  expect(await run(router, ['foo', '--user-id', '123', '--name', 'bob', '--admin'])).toMatchInlineSnapshot(
+    `"{"userId":123,"name":"bob","admin":true}"`,
+  )
+  await expect(run(router, ['foo', '--name', 'bob'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: required option '--user-id <number>' not specified
+  `)
+  await expect(run(router, ['foo', '--user-id', '123'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: required option '--name <string>' not specified
+  `)
+})


### PR DESCRIPTION
## Summary

This reopens the TypeBox support work as a pull request after reverting it from `main`, so the implementation can be reviewed and adjusted before it ships.

If merged as-is, this restores the TypeBox Standard Schema adapter, the TypeBox validator tests, optional peer/dev dependency metadata, and README documentation for `typeboxToStandardSchema`.

```ts
import Type from "typebox"
import {typeboxToStandardSchema} from "trpc-cli"

t.procedure
  .input(typeboxToStandardSchema(Type.Object({name: Type.String()})))
  .query(({input}) => input.name)
```

## Review Notes

This is intentionally just the unrevert. Follow-up review should focus on whether the adapter should live under a separate `trpc-cli/typebox` entrypoint and whether its helper types should rely directly on TypeBox's exported types instead of recreating static inference locally.

## Verification

Not run for this unrevert-only branch.