### PR TITLE
Don't add `--json` option to commands with no inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ When `--json` is passed, it must supply the *whole* input - schema-derived flags
 
 If a procedure's input schema defines its own `json` property, the schema wins: that command keeps its regular schema-derived `--json` flag, and the JSON-input behavior is disabled for it.
 
+Commands whose procedures accept no input at all (no `.input(...)`, or an empty object schema) never get a `--json` option, in any mode - there's nothing to provide.
+
 The `jsonInput` setting accepts `'never'` (the default - commands don't accept `--json`), `'auto'` (described above) or `'always'`, either CLI-wide via `createCli({jsonInput: ...})` or per procedure in its meta (the meta value takes precedence):
 
 ```ts

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -14,7 +14,7 @@ if (!filepath || filepath === '--help' || filepath === '-h') {
       'Runs a TypeScript/JavaScript module of plain exported functions as a CLI (experimental).',
       'Each exported function becomes a command: leading string/number/boolean parameters become',
       'positional arguments, a trailing object parameter becomes flags, and jsdoc comments become',
-      'help text. Every command also accepts its full input as `--json <json>`.',
+      'help text. Commands that take input also accept it all at once as `--json <json>`.',
       '',
       'Example:',
       '  // commands.ts',

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,17 +254,23 @@ export function createCli<R extends AnyRouter>(
     const configureCommand = (command: Command, procedurePath: string, info: ProcedureInfo) => {
       const {meta} = info
       const jsonInputMode = resolveJsonInputMode(meta.jsonInput, params.jsonInput)
+      // parse the schema regardless of mode (neutralizing the meta 'always' shortcut inside getParsedProcedure,
+      // which is handled below) so we can tell whether the procedure accepts any input at all
+      const schemaDerived = getParsedProcedure({...info, meta: {...info.meta, jsonInput: undefined}})
+      const schemaProperties = flattenedProperties(schemaDerived.optionsJsonSchema)
+      const hasNoInputs = schemaDerived.positionalParameters.length === 0 && Object.keys(schemaProperties).length === 0
       let parsedProcedure: ParsedProcedure
       let addCosmeticJsonOption = false
-      if (jsonInputMode === 'always') {
+      if (hasNoInputs) {
+        // a procedure that accepts no input has nothing to provide as JSON - never offer `--json`, in any mode.
+        // (unparseable schemas don't land here: their fallback parse has a real `json` option, i.e. it HAS an input)
+        parsedProcedure = schemaDerived
+      } else if (jsonInputMode === 'always') {
         parsedProcedure = jsonProcedureInputs()
       } else {
-        const schemaDerived = getParsedProcedure(info)
         // schema-wins guard: if the schema already derives a `json` option (including the unparseable-schema fallback,
         // which *is* a real `--json` option), the schema keeps it - no JSON-only build, no cosmetic help option
-        const schemaHasJsonOption = Object.keys(flattenedProperties(schemaDerived.optionsJsonSchema)).some(
-          key => kebabCase(key) === 'json',
-        )
+        const schemaHasJsonOption = Object.keys(schemaProperties).some(key => kebabCase(key) === 'json')
         if (jsonInputMode === 'auto' && !schemaHasJsonOption && jsonFlagSniffed) {
           parsedProcedure = jsonProcedureInputs()
         } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ export interface TrpcCliParams<R extends AnyRouter> extends Dependencies {
    * - `'auto'`: every command accepts `--json` as an alternative to its schema-derived flags and positional arguments. When `--json` is passed it must be the *only* input - combining it with other flags or positional arguments results in an unknown option error. Exception: if a procedure's schema already defines a `json` property, the schema wins - that command keeps its regular schema-derived `--json` flag.
    * - `'always'`: every command *only* accepts `--json` - no schema-derived flags or positional arguments.
    *
+   * Commands whose procedures accept no input at all never get `--json`, in any mode - there's nothing to provide.
+   *
    * Individual procedures can override this with `jsonInput` in their meta.
    */
   jsonInput?: JsonInputMode

--- a/test/json-input.test.ts
+++ b/test/json-input.test.ts
@@ -191,6 +191,32 @@ test('help in flags mode shows --json on leaf commands; json-mode help shows onl
   `)
 })
 
+test(`commands with no inputs never get --json`, async () => {
+  const router = t.router({
+    ping: t.procedure.query(() => 'pong'), // no .input() at all
+    empty: t.procedure.input(z.object({})).query(() => 'ok'), // empty object schema
+    greet: t.procedure.input(z.object({name: z.string()})).query(({input}) => `hello ${input.name}`),
+  })
+  const params = {router, jsonInput: 'auto'} as const
+
+  // there's nothing to provide as JSON, so --json isn't offered - and isn't accepted
+  expect(await runWith(params, ['ping', '--help'])).not.toContain('--json')
+  expect(await runWith(params, ['empty', '--help'])).not.toContain('--json')
+  await expect(runWith(params, ['ping', '--json', '{}'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: unknown option '--json'
+  `)
+  expect(await runWith(params, ['ping'])).toMatchInlineSnapshot(`"pong"`)
+
+  // sibling commands with inputs still get --json as usual
+  expect(await runWith(params, ['greet', '--help'])).toContain('--json')
+  expect(await runWith(params, ['greet', '--json', '{"name":"Ada"}'])).toMatchInlineSnapshot(`"hello Ada"`)
+
+  // same for 'always' mode: JSON-only would mean no inputs anyway, so the option is dropped there too
+  expect(await runWith({router, jsonInput: 'always'}, ['ping', '--help'])).not.toContain('--json')
+  expect(await runWith({router, jsonInput: 'always'}, ['ping'])).toMatchInlineSnapshot(`"pong"`)
+})
+
 test(`jsonInput: 'never' disables --json globally`, async () => {
   const router = t.router({
     object: t.procedure.input(z.object({foo: z.string().optional()})).query(({input}) => JSON.stringify(input)),


### PR DESCRIPTION
With `jsonInput: 'auto'` (or `'always'` — including via the `trpc-cli` bin, which uses `'auto'`), commands whose procedures accept no input still got a `--json <json>` option. There's nothing to provide, so it was pure noise in `--help` and an invitation to pass junk.

```ts
const router = t.router({
  ping: t.procedure.query(() => 'pong'),
})
void createCli({router, jsonInput: 'auto'}).run()
```

```console
# before
$ mycli ping --help
Options:
  --json <json>  Provide the complete procedure input as JSON - ...
  -h, --help     display help for command

# after
$ mycli ping --help
Options:
  -h, --help  display help for command

$ mycli ping --json '{}'
error: unknown option '--json'
```

Applies to procedures with no `.input(...)` and to empty object schemas (`z.object({})`), in every `jsonInput` mode. Unparseable schemas are unaffected — their `--json` fallback is the only way to pass input, so it stays.

Implementation note: the schema is now parsed up front regardless of mode (neutralizing `getParsedProcedure`'s internal meta-`'always'` shortcut, which `configureCommand` already handles itself), so "has no inputs" can be decided before choosing between schema-derived and JSON-only builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)