### PR TITLE
Support TS function overloads in module mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,11 @@ TypeScript function overloads become alternate calling conventions for a single 
 ```ts
 // commands.ts
 /** resize by explicit dimensions */
-export function resize(params: {input: string; width: number; height: number}): Promise<string>
+export function resize(params: {
+  input: string
+  width: number
+  height: number
+}): Promise<string>
 /** resize by scale factor, preserving aspect ratio */
 export function resize(params: {input: string; scale: number}): Promise<string>
 export function resize(params: any) {

--- a/README.md
+++ b/README.md
@@ -752,6 +752,30 @@ export async function copy(
 
 Inline jsdoc before a parameter (`/** the file to copy */ source: string`) becomes the positional argument's description.
 
+TypeScript function overloads become alternate calling conventions for a single command, when every signature takes a single object parameter:
+
+```ts
+// commands.ts
+/** resize by explicit dimensions */
+export function resize(params: {input: string; width: number; height: number}): Promise<string>
+/** resize by scale factor, preserving aspect ratio */
+export function resize(params: {input: string; scale: number}): Promise<string>
+export function resize(params: any) {
+  // the implementation dispatches on the input's shape, as overload implementations always do
+}
+```
+
+Help shows one usage line per signature (with its jsdoc as a trailing comment):
+
+```console
+$ mycli resize --help
+Usage: mycli resize --input <string> --width <number> --height <number>  # resize by explicit dimensions
+       mycli resize --input <string> --scale <number>                    # resize by scale factor, preserving aspect ratio
+...
+```
+
+The flags list is the union of all signatures' flags, and flags that never appear in the same signature conflict (`--width` can't be combined with `--scale`). At runtime, the input is validated against each signature's schema in declaration order - mirroring TypeScript's own overload resolution - and the first match is passed to the function. If nothing matches, the error reports each signature's issues, closest match first.
+
 Details and limitations:
 
 - `filename` accepts an absolute path (robust - works from any directory), `import.meta` (when the call lives in the commands file itself), or a `URL` like `new URL('./commands.ts', import.meta.url)` (resolves relative to the importing file, so a distributed CLI works wherever it's invoked). A *relative* path string is resolved against `process.cwd()`, so it's only reliable when the CLI is run from a known directory - fine for quick scripts, but it breaks the moment a globally-installed CLI runs somewhere else, so prefer `import.meta`/`URL` for anything you distribute. For `.ts` modules, run under tsx, bun, deno, or node >=22.18 (which strip types natively).
@@ -759,7 +783,7 @@ Details and limitations:
 - Parameter types can be inline literals (`{foo: string}`, `'fast' | 'slow'`), references to a `type X = {...}`/`interface X {...}` declared in the same file, or relative file-backed type imports such as `import type {Options} from './types.ts'`. Interface `extends` clauses and intersections of object literals like `type X = {a: string} & {b: number}` are flattened into one set of flags when possible. Functions with no parameters become commands with no arguments.
 - Only the *last* parameter can be an object type (it maps to flags); the others must be strings, numbers, booleans, or arrays of those (a `files: string[]` parameter becomes a variadic positional). Rest parameters and destructured positional parameters aren't supported.
 - Supported declaration syntaxes: `export function f(...)`, `export async function f(...)`, `export const f = (...) => ...` (including `export const f = async (...) => ...`; type-annotated consts like `export const f: Cmd = ...` aren't parsed), `export default function f(...)` (anonymous default functions become a command named `default`), `export class Group { method(...) {} }`, `export default class Commands { method(...) {} }`, `export * as group from './group'`, `export * from './group'`, and `export {commandOrGroup} from './group'`. The module must export *only* commands: any other exported function - a local `export {f}` statement or a declaration the extractor can't parse - makes the CLI fail at startup with an error naming the offending export (failing loudly beats silently dropping a command). Keep helpers in a separate, un-re-exported module.
-- Overloaded functions work, with a simple rule: only the *first* overload signature is used; later overloads and the implementation signature are ignored. TypeScript resolves calls against overload signatures in order, so the first one is the primary documented shape - and a CLI can only present one calling convention.
+- Overloaded functions (and class methods) become alternate calling conventions as described above when every signature takes a single object parameter. Signatures involving positional parameters can't be presented as alternatives (commander has no way to show alternate positional layouts for one command), so those fall back to using only the *first* overload signature - the primary documented shape, since TypeScript resolves calls against signatures in order. The implementation signature is always ignored.
 - For bundlers/browsers (no filesystem, no dynamic import), pass the source and exports explicitly: `createCli({source: rawSourceText, exports: await import('./commands.js')})`. Re-exported command modules are not supported in this form because trpc-cli has no filesystem location to resolve child modules from.
 - In this mode `run`/`buildProgram`/`toJSON` are all **async** (the module is loaded asynchronously): `const program = await createCli(import.meta).buildProgram()`. With a router, `buildProgram`/`toJSON` are synchronous.
 - Don't pass user-controlled strings as `filename` - the path is read and dynamically imported, i.e. executed.

--- a/README.md
+++ b/README.md
@@ -778,7 +778,9 @@ Usage: mycli resize --input <string> --width <number> --height <number>  # resiz
 ...
 ```
 
-The flags list is the union of all signatures' flags, and flags that never appear in the same signature conflict (`--width` can't be combined with `--scale`). At runtime, the input is validated against each signature's schema in declaration order - mirroring TypeScript's own overload resolution - and the first match is passed to the function. If nothing matches, the error reports each signature's issues, closest match first.
+The flags list is the union of all signatures' flags, and flags that never appear in the same signature conflict (`--width` can't be combined with `--scale`) - their help descriptions are annotated with `Do not use with: ...`. At runtime, the input is validated against each signature's schema in declaration order - mirroring TypeScript's own overload resolution - and the first match is passed to the function. If nothing matches, the error reports each signature's issues, closest match first.
+
+jsdoc conventions for overloaded commands: each signature's jsdoc describes *its* calling convention (it becomes that usage line's `#` comment); a jsdoc on the *implementation* signature describes the command as a whole (shown as the command description - without one, the signatures' descriptions are joined). Property jsdoc works as usual, and a flag documented differently in different signatures (say, an `input` that means a URL in one and a file path in another) shows each distinct description, joined with `/`.
 
 Details and limitations:
 

--- a/README.md
+++ b/README.md
@@ -764,8 +764,15 @@ export function resize(params: {
 }): Promise<string>
 /** resize by scale factor, preserving aspect ratio */
 export function resize(params: {input: string; scale: number}): Promise<string>
-export function resize(params: any) {
-  // the implementation dispatches on the input's shape, as overload implementations always do
+/** resize an image */
+export function resize(params: {
+  input: string
+  width?: number
+  height?: number
+  scale?: number
+}) {
+  // the implementation dispatches on the input's shape, as overload implementations always do.
+  // its jsdoc (if any) becomes the command's overall description
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,7 +348,21 @@ export function createCli<R extends AnyRouter>(
             return propertyKey // by default commander uses camelcase(this.name()) which turns `use-mcp-server` into `useMcpServer` - when it might be `useMCPServer`
           }
         }
-        const description = getDescription(propertyValue)
+        // union inputs (including module-mode overloads) produce flags that can't be combined - say so in help,
+        // since commander's `conflicts` otherwise only surfaces at error time
+        const incompatibleWith = [
+          ...new Set(
+            incompatiblePairs.flatMap(pair => (pair.includes(propertyKey) ? pair.filter(p => p !== propertyKey) : [])),
+          ),
+        ]
+        const description = [
+          getDescription(propertyValue),
+          incompatibleWith.length > 0
+            ? `Do not use with: ${incompatibleWith.map(other => `--${kebabCase(other)}`).join(', ')}`
+            : '',
+        ]
+          .filter(Boolean)
+          .join('; ')
 
         const longOption = `--${kebabCase(propertyKey)}`
         let flags = longOption

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,7 +296,24 @@ export function createCli<R extends AnyRouter>(
       })
       command.showHelpAfterError()
 
-      if (meta.usage) command.usage([meta.usage].flat().join('\n'))
+      if (meta.usage) {
+        const usageLines = [meta.usage].flat()
+        command.usage(usageLines.join('\n'))
+        if (usageLines.length > 1) {
+          // align each usage line under `Usage: `, repeating the full command prefix (like git's multi-line usage) -
+          // without this, commander renders continuation lines unindented at column 0
+          command.configureHelp({
+            commandUsage: cmd => {
+              let prefix = cmd.name()
+              if (cmd.aliases()[0]) prefix += `|${cmd.aliases()[0]}`
+              for (let ancestor = cmd.parent; ancestor; ancestor = ancestor.parent) {
+                prefix = `${ancestor.name()} ${prefix}`
+              }
+              return usageLines.map(line => `${prefix} ${line}`).join('\n' + ' '.repeat('Usage: '.length))
+            },
+          })
+        }
+      }
       if (meta.examples) command.addHelpText('after', `\nExamples:\n${[meta.examples].flat().join('\n')}`)
 
       meta?.aliases?.command?.forEach(alias => {

--- a/src/module-commands.ts
+++ b/src/module-commands.ts
@@ -21,8 +21,12 @@
  * parameter's name + balanced `{...}` (or named-reference) type annotation text. The heavy lifting - turning type
  * syntax into JSON Schema - is all `Type.Script`.
  */
+import {flattenedProperties, getEnumChoices} from './json-schema.js'
 import {t} from './norpc.js'
+import {isOptional} from './parse-procedure.js'
 import {NorpcProcedureLike, NorpcRouterLike} from './parse-router.js'
+import {StandardSchemaV1} from './standard-schema/contract.js'
+import {toDotPath} from './standard-schema/errors.js'
 import Type from './typebox/index.js'
 import {getSchemaTypes, kebabCase} from './util.js'
 
@@ -74,7 +78,20 @@ export interface ExtractedCommand {
   default: boolean
   /** cleaned jsdoc text from the comment immediately preceding the export - becomes the command description */
   description: string | undefined
-  /** the function's parameters, in declaration order. Empty = command with no args */
+  /** the function's parameters, in declaration order. Empty = command with no args. For overloaded functions, the first signature's parameters */
+  params: ExtractedParam[]
+  /**
+   * present when the function is declared with multiple TS overload signatures: one entry per body-less signature,
+   * in declaration order (the first entry mirrors `description`/`params`). The implementation signature is never
+   * included. See `buildOverloadedProcedure` for how overloads become alternate calling conventions.
+   */
+  overloads?: ExtractedOverload[]
+}
+
+/** One signature of a command declared with multiple TS overload signatures. */
+export interface ExtractedOverload {
+  /** cleaned jsdoc text from the comment immediately preceding this signature */
+  description: string | undefined
   params: ExtractedParam[]
 }
 
@@ -357,6 +374,11 @@ const buildProcedure = (command: ExtractedCommand, fn: AnyFn, context: Record<st
     ...(command.default ? {default: true} : {}),
     ...(commandDoc.aliases.length > 0 ? {aliases: {command: commandDoc.aliases}} : {}),
   }
+  if (command.overloads) {
+    const overloaded = buildOverloadedProcedure(command, fn, context, meta)
+    if (overloaded) return overloaded
+  }
+
   const builder = Object.keys(meta).length > 0 ? t.procedure.meta(meta) : t.procedure
   if (command.params.length === 0) {
     return builder.handler(() => fn())
@@ -370,6 +392,162 @@ const buildProcedure = (command: ExtractedCommand, fn: AnyFn, context: Record<st
   }
 
   return buildPositionalProcedure(builder, command, fn, context, paramSchemas)
+}
+
+interface OverloadVariant {
+  schema: unknown
+  /** flags summary shown as this variant's usage line, e.g. `--name <string> [--dev]` */
+  flags: string
+  /** first line of this signature's jsdoc, shown as a comment on its usage line */
+  description: string | undefined
+}
+
+/**
+ * TS function overloads where every signature takes a single object(-like) parameter become a command with
+ * alternate calling conventions: help shows one usage line per signature, the flags list is the union of all
+ * signatures' flags (the existing union-of-objects derivation in parse-procedure.ts, including commander
+ * `conflicts` for flags that never appear in the same signature), and validation checks each signature's schema
+ * in declaration order - mirroring TS overload resolution - passing the first match to the function. The runtime
+ * implementation dispatches on the input's shape itself, as overload implementations always do, so it doesn't
+ * need to be told which signature matched. When nothing matches, the error reports each signature's issues,
+ * closest match (fewest issues) first.
+ *
+ * Returns undefined for any other overload shape (positional parameters, differing arity, unparseable types),
+ * falling back to the first signature only - the behavior before overload support existed. Positional parameters
+ * are excluded because commander has no way to present alternate positional layouts for one command.
+ */
+const buildOverloadedProcedure = (
+  command: ExtractedCommand,
+  fn: AnyFn,
+  context: Record<string, unknown>,
+  meta: Record<string, unknown>,
+): NorpcProcedureLike | undefined => {
+  const variants: OverloadVariant[] = []
+  for (const overload of command.overloads!) {
+    if (overload.params.length !== 1) return undefined
+    let schema: unknown
+    try {
+      schema = parseParamSchema(command.name, overload.params[0], context)
+    } catch (error) {
+      if (error instanceof SkippedModuleCommandError) return undefined
+      throw error
+    }
+    if (!isObjectLikeSchema(schema)) return undefined
+    variants.push({
+      schema,
+      flags: overloadFlagsSummary(schema),
+      description: parseCliJsdoc(overload.description).description?.split('\n')[0],
+    })
+  }
+
+  fillSharedFlagMetadata(variants)
+
+  const combined = {anyOf: variants.map(variant => variant.schema)}
+  Object.defineProperty(combined, '~standard', {
+    configurable: true,
+    enumerable: false,
+    value: {
+      version: 1,
+      vendor: 'trpc-cli',
+      validate: (input: unknown) => validateOverloads(variants, input),
+      jsonSchema: {input: () => combined, output: () => combined},
+    },
+  })
+
+  const flagsWidth = Math.max(...variants.map(variant => variant.flags.length))
+  const usage = variants.map(variant =>
+    variant.description ? `${variant.flags.padEnd(flagsWidth)}  # ${variant.description}` : variant.flags,
+  )
+  return t.procedure
+    .meta({...meta, usage})
+    .input(combined as never)
+    .handler(({input}) => fn(input))
+}
+
+/** Validate against each overload's schema in declaration order, first match wins - the CLI equivalent of TS overload resolution. */
+const validateOverloads = (variants: OverloadVariant[], input: unknown): StandardSchemaV1.Result<unknown> => {
+  const failures: Array<{variant: OverloadVariant; issues: readonly StandardSchemaV1.Issue[]}> = []
+  for (const variant of variants) {
+    const result = (variant.schema as StandardSchemaV1)['~standard'].validate(input)
+    if (result instanceof Promise) throw new TypeError('Overload schemas must validate synchronously') // Type.Script validators always do
+    if (!result.issues) return result
+    failures.push({variant, issues: result.issues})
+  }
+  // the signature producing the fewest issues is the one the user was closest to matching - report it first
+  // (ties keep declaration order, since `sort` is stable)
+  const sorted = [...failures].sort((a, b) => a.issues.length - b.issues.length)
+  const lines = sorted.map(failure => {
+    const details = failure.issues.map(issue => {
+      const path = (issue.path || []).map(segment => (typeof segment === 'object' ? segment.key : segment))
+      return issue.message + (path.length > 0 ? ` (${toDotPath(path)})` : '')
+    })
+    return `  ${failure.variant.flags}: ${details.join('; ')}`
+  })
+  const message = `matched none of the ${variants.length} ways to call this command:\n${lines.join('\n')}`
+  return {issues: [{message}]}
+}
+
+/**
+ * A one-line usage summary of an overload signature's flags, e.g. `--name <string> --global [--save-dir <string>]`.
+ * Booleans (including `true` literals like `global: true`) show as bare flags, string-literal unions show their
+ * choices, everything else shows its type; flags that aren't required in every branch of the (possibly union)
+ * schema are bracketed.
+ */
+const overloadFlagsSummary = (schema: unknown): string => {
+  const properties = flattenedProperties(schema as never)
+  const required = requiredInAllBranches(schema)
+  const parts = Object.entries(properties).map(([key, propertySchema]) => {
+    const flag = `--${kebabCase(key)}`
+    const types = getSchemaTypes(propertySchema).filter(type => type !== 'undefined' && type !== 'null')
+    const enumChoices = getEnumChoices(propertySchema)
+    let placeholder: string | null
+    if (types.length === 1 && types[0] === 'boolean') placeholder = null
+    else if (enumChoices?.type === 'string_enum') placeholder = enumChoices.choices.join('|')
+    else if (types.length === 1 && types[0] === 'array') placeholder = 'values...'
+    else placeholder = types.join('|') || 'value'
+    const part = placeholder ? `${flag} <${placeholder}>` : flag
+    return required.has(key) && !isOptional(propertySchema) ? part : `[${part}]`
+  })
+  return parts.join(' ')
+}
+
+/**
+ * A flag shared between overload signatures keeps its jsdoc even when only one signature documents it: the union
+ * flag-merge in `flattenedProperties` keeps the *last* occurrence of each property, so a description or `@alias`
+ * declared on an earlier signature would silently disappear from help. Copy them (first occurrence wins) onto
+ * same-named properties that lack them. Cosmetic metadata only - validation behavior is unaffected.
+ */
+const fillSharedFlagMetadata = (variants: OverloadVariant[]) => {
+  const branches = variants.flatMap(variant => objectBranches(variant.schema))
+  for (const key of ['description', 'alias']) {
+    const firstValues = new Map<string, unknown>()
+    for (const branch of branches) {
+      for (const [name, property] of Object.entries(branch.properties || {})) {
+        if (!firstValues.has(name) && property[key] !== undefined) firstValues.set(name, property[key])
+      }
+    }
+    for (const branch of branches) {
+      for (const [name, property] of Object.entries(branch.properties || {})) {
+        if (property[key] === undefined && firstValues.has(name)) property[key] = firstValues.get(name)
+      }
+    }
+  }
+}
+
+const objectBranches = (schema: unknown): Array<{properties?: Record<string, Record<string, unknown>>}> => {
+  const {anyOf} = (schema || {}) as {anyOf?: unknown[]}
+  if (Array.isArray(anyOf)) return anyOf.flatMap(objectBranches)
+  return [schema as never]
+}
+
+/** Property names required in every branch of a (possibly `anyOf`-union) object schema. */
+const requiredInAllBranches = (schema: unknown): Set<string> => {
+  const {required, anyOf} = (schema || {}) as {required?: string[]; anyOf?: unknown[]}
+  if (Array.isArray(anyOf)) {
+    const sets = anyOf.map(requiredInAllBranches)
+    return new Set([...(sets[0] || [])].filter(key => sets.every(set => set.has(key))))
+  }
+  return new Set(required || [])
 }
 
 /**
@@ -786,8 +964,8 @@ const parseNamedSpecifiers = (
  * parameter list (names, optionality, type annotation text, inline jsdoc). Supports `export function f(...)`,
  * `export async function f(...)`, `export const f = (...) => ...` (parenthesized arrows only), and
  * `export default function f(...)` (or an anonymous default function, which becomes a command named `default`).
- * Returns one command per export name: TS function overloads extract once per declaration, and the first overload
- * *signature* wins (see the dedupe note inline).
+ * Returns one command per export name: TS function overloads extract once per declaration, and all the overload
+ * *signatures* become the command's calling conventions (see the grouping note inline).
  */
 export const extractModuleCommands = (source: string): ExtractedCommand[] => {
   const scan = scanSource(source)
@@ -844,24 +1022,48 @@ export const extractModuleCommands = (source: string): ExtractedCommand[] => {
   // matchAll over two patterns can't interleave, so restore source order - it determines command order in --help
   declarations.sort((a, b) => a.position - b.position)
 
-  // One command per name, first extraction wins - with one twist for TS function overloads. Overloads extract once
-  // per declaration: the body-less *signatures* come first and the *implementation* (whose params are typically
-  // widened, e.g. `options: any`) last. TS resolves calls against the signatures in order, so the FIRST signature
-  // is the primary documented shape - it becomes the command, and the implementation signature and later overloads
-  // are ignored (a CLI can only present one calling convention; a union of all signatures was considered and
-  // rejected, since it would advertise flag combinations no single overload accepts). The `hasBody` preference only
-  // matters if an implementation somehow precedes a signature - in valid TS, first-wins already picks the first
-  // signature. Params are parsed only for the winners, so an unannotated implementation (`function f(options) {`)
-  // can't poison a command whose signatures are fine.
-  const winners = new Map<string, (typeof declarations)[number]>()
+  // One command per name - with special handling for TS function overloads, which extract once per declaration:
+  // the body-less *signatures* come first and the *implementation* (whose params are typically widened, e.g.
+  // `options: any`) last. TS resolves calls against the signatures in order, so when signatures exist they ALL
+  // become the command's calling conventions, in declaration order: buildOverloadedProcedure turns
+  // single-object-parameter overloads into alternate flag sets validated first-match; any other overload shape
+  // falls back to just the first signature. The implementation signature is never used, so an unannotated
+  // implementation (`function f(options) {`) can't poison a command whose signatures are fine, and signatures
+  // whose params fail to parse are dropped individually rather than sinking the whole command.
+  return groupOverloadDeclarations(declarations).flatMap((group): ExtractedCommand[] => {
+    const overloads = group.flatMap(declaration => {
+      const params = tryParseParams(declaration.name, declaration.paramList)
+      return params ? [{description: declaration.description, params}] : []
+    })
+    if (overloads.length === 0) return []
+    const {name, exportName, default: defaultExport} = group[0]
+    return [
+      {
+        name,
+        exportName,
+        default: defaultExport,
+        description: overloads[0].description,
+        params: overloads[0].params,
+        ...(overloads.length > 1 ? {overloads} : {}),
+      },
+    ]
+  })
+}
+
+/**
+ * Group declarations sharing a name, keeping the declarations that define the command's calling convention(s):
+ * all body-less overload signatures when any exist (in declaration order), otherwise the first implementation.
+ */
+const groupOverloadDeclarations = <D extends {name: string; hasBody: boolean}>(declarations: D[]): D[][] => {
+  const groups = new Map<string, D[]>()
   for (const declaration of declarations) {
-    const existing = winners.get(declaration.name)
-    if (!existing || (existing.hasBody && !declaration.hasBody)) winners.set(declaration.name, declaration)
+    const group = groups.get(declaration.name)
+    if (group) group.push(declaration)
+    else groups.set(declaration.name, [declaration])
   }
-  return [...winners.values()].flatMap(({name, exportName, default: defaultExport, description, paramList}) => {
-    const params = tryParseParams(name, paramList)
-    if (!params) return []
-    return [{name, exportName, default: defaultExport, description, params}]
+  return [...groups.values()].map(group => {
+    const signatures = group.filter(declaration => !declaration.hasBody)
+    return signatures.length > 0 ? signatures : group.slice(0, 1)
   })
 }
 
@@ -895,10 +1097,22 @@ export const extractModuleClasses = (source: string): ExtractedClass[] => {
       if (hasConstructorParameters) continue
       if (hasBaseClass && !hasZeroArgConstructor) continue
       if (methodDeclarations.length === 0) continue
-      const methods = methodDeclarations.flatMap(({methodName, description, paramList}) => {
-        const params = tryParseParams(`${name}.${methodName}`, paramList)
-        if (!params) return []
-        return [{name: methodName, exportName: methodName, default: false, description, params}]
+      const methods = methodDeclarations.flatMap(({methodName, signatures}): ExtractedCommand[] => {
+        const overloads = signatures.flatMap(signature => {
+          const params = tryParseParams(`${name}.${methodName}`, signature.paramList)
+          return params ? [{description: signature.description, params}] : []
+        })
+        if (overloads.length === 0) return []
+        return [
+          {
+            name: methodName,
+            exportName: methodName,
+            default: false,
+            description: overloads[0].description,
+            params: overloads[0].params,
+            ...(overloads.length > 1 ? {overloads} : {}),
+          },
+        ]
       })
       if (methods.length === 0) continue
       classes.push({name, exportName, default: defaultExport, methods})
@@ -921,7 +1135,11 @@ const extractClassMethodDeclarations = (
   bodyStart: number,
   bodyEnd: number,
 ): {
-  methodDeclarations: Array<{methodName: string; description: string | undefined; paramList: string}>
+  methodDeclarations: Array<{
+    methodName: string
+    /** one per body-less overload signature, or a single entry for a plain method - same rule as `groupOverloadDeclarations` */
+    signatures: Array<{description: string | undefined; paramList: string}>
+  }>
   hasConstructorParameters: boolean
   hasZeroArgConstructor: boolean
 } => {
@@ -981,19 +1199,13 @@ const extractClassMethodDeclarations = (
   }
 
   declarations.sort((a, b) => a.position - b.position)
-  const winners = new Map<string, (typeof declarations)[number]>()
-  for (const declaration of declarations) {
-    const existing = winners.get(declaration.name)
-    if (!existing || (existing.hasBody && !declaration.hasBody)) winners.set(declaration.name, declaration)
-  }
 
   return {
     hasConstructorParameters,
     hasZeroArgConstructor,
-    methodDeclarations: [...winners.values()].map(({name, description, paramList}) => ({
-      methodName: name,
-      description,
-      paramList,
+    methodDeclarations: groupOverloadDeclarations(declarations).map(group => ({
+      methodName: group[0].name,
+      signatures: group.map(({description, paramList}) => ({description, paramList})),
     })),
   }
 }

--- a/src/module-commands.ts
+++ b/src/module-commands.ts
@@ -86,6 +86,12 @@ export interface ExtractedCommand {
    * included. See `buildOverloadedProcedure` for how overloads become alternate calling conventions.
    */
   overloads?: ExtractedOverload[]
+  /**
+   * cleaned jsdoc of the overload *implementation* signature, when the export is overloaded. Each overload
+   * signature's jsdoc describes just that calling convention, so this is the natural home for a description of
+   * the command as a whole.
+   */
+  implementationDescription?: string
 }
 
 /** One signature of a command declared with multiple TS overload signatures. */
@@ -458,8 +464,25 @@ const buildOverloadedProcedure = (
   const usage = variants.map(variant =>
     variant.description ? `${variant.flags.padEnd(flagsWidth)}  # ${variant.description}` : variant.flags,
   )
+
+  // Command-level description: each signature's jsdoc describes *its* calling convention (shown as that usage
+  // line's comment), so presenting the first signature's jsdoc as the whole command's description would be
+  // misleadingly universal. The implementation signature's jsdoc is the natural home for an overall description;
+  // failing that, the signatures' (distinct) descriptions are joined. Command `@alias`es are honored wherever
+  // they're declared.
+  const implementationDoc = parseCliJsdoc(command.implementationDescription)
+  const variantDocs = command.overloads!.map(overload => parseCliJsdoc(overload.description))
+  const distinctDescriptions = [...new Set(variantDocs.map(doc => doc.description).filter(Boolean))]
+  const description = implementationDoc.description || distinctDescriptions.join(' / ')
+  const aliases = [...new Set([...implementationDoc.aliases, ...variantDocs.flatMap(doc => doc.aliases)])]
+  const overloadedMeta: Record<string, unknown> = {...meta, usage}
+  if (description) overloadedMeta.description = description
+  else delete overloadedMeta.description
+  if (aliases.length > 0) overloadedMeta.aliases = {command: aliases}
+  else delete overloadedMeta.aliases
+
   return t.procedure
-    .meta({...meta, usage})
+    .meta(overloadedMeta)
     .input(combined as never)
     .handler(({input}) => fn(input))
 }
@@ -512,24 +535,32 @@ const overloadFlagsSummary = (schema: unknown): string => {
 }
 
 /**
- * A flag shared between overload signatures keeps its jsdoc even when only one signature documents it: the union
- * flag-merge in `flattenedProperties` keeps the *last* occurrence of each property, so a description or `@alias`
- * declared on an earlier signature would silently disappear from help. Copy them (first occurrence wins) onto
- * same-named properties that lack them. Cosmetic metadata only - validation behavior is unaffected.
+ * Reconcile per-flag jsdoc across overload signatures. The union flag-merge in `flattenedProperties` keeps the
+ * *last* occurrence of each property, which would silently drop a description or `@alias` declared on an earlier
+ * signature. Descriptions: a flag documented in one signature (or identically in several) keeps that text; a flag
+ * documented *differently* per signature (e.g. an `input` accepting subtly different values) shows every distinct
+ * description, joined with ' / ' in declaration order. Aliases: first occurrence wins. Cosmetic metadata only -
+ * validation behavior is unaffected.
  */
 const fillSharedFlagMetadata = (variants: OverloadVariant[]) => {
   const branches = variants.flatMap(variant => objectBranches(variant.schema))
-  for (const key of ['description', 'alias']) {
-    const firstValues = new Map<string, unknown>()
-    for (const branch of branches) {
-      for (const [name, property] of Object.entries(branch.properties || {})) {
-        if (!firstValues.has(name) && property[key] !== undefined) firstValues.set(name, property[key])
+  const descriptions = new Map<string, string[]>()
+  const aliases = new Map<string, unknown>()
+  for (const branch of branches) {
+    for (const [name, property] of Object.entries(branch.properties || {})) {
+      if (typeof property.description === 'string') {
+        const distinct = descriptions.get(name) || []
+        if (!distinct.includes(property.description)) distinct.push(property.description)
+        descriptions.set(name, distinct)
       }
+      if (property.alias !== undefined && !aliases.has(name)) aliases.set(name, property.alias)
     }
-    for (const branch of branches) {
-      for (const [name, property] of Object.entries(branch.properties || {})) {
-        if (property[key] === undefined && firstValues.has(name)) property[key] = firstValues.get(name)
-      }
+  }
+  for (const branch of branches) {
+    for (const [name, property] of Object.entries(branch.properties || {})) {
+      const description = descriptions.get(name)?.join(' / ')
+      if (description) property.description = description
+      if (aliases.has(name)) property.alias = aliases.get(name)
     }
   }
 }
@@ -1030,13 +1061,13 @@ export const extractModuleCommands = (source: string): ExtractedCommand[] => {
   // falls back to just the first signature. The implementation signature is never used, so an unannotated
   // implementation (`function f(options) {`) can't poison a command whose signatures are fine, and signatures
   // whose params fail to parse are dropped individually rather than sinking the whole command.
-  return groupOverloadDeclarations(declarations).flatMap((group): ExtractedCommand[] => {
-    const overloads = group.flatMap(declaration => {
+  return groupOverloadDeclarations(declarations).flatMap(({winners, implementation}): ExtractedCommand[] => {
+    const overloads = winners.flatMap(declaration => {
       const params = tryParseParams(declaration.name, declaration.paramList)
       return params ? [{description: declaration.description, params}] : []
     })
     if (overloads.length === 0) return []
-    const {name, exportName, default: defaultExport} = group[0]
+    const {name, exportName, default: defaultExport} = winners[0]
     return [
       {
         name,
@@ -1044,17 +1075,20 @@ export const extractModuleCommands = (source: string): ExtractedCommand[] => {
         default: defaultExport,
         description: overloads[0].description,
         params: overloads[0].params,
-        ...(overloads.length > 1 ? {overloads} : {}),
+        ...(overloads.length > 1 ? {overloads, implementationDescription: implementation?.description} : {}),
       },
     ]
   })
 }
 
 /**
- * Group declarations sharing a name, keeping the declarations that define the command's calling convention(s):
+ * Group declarations sharing a name. `winners` are the declarations defining the command's calling convention(s):
  * all body-less overload signatures when any exist (in declaration order), otherwise the first implementation.
+ * The implementation declaration is kept separately - its jsdoc can describe an overloaded command as a whole.
  */
-const groupOverloadDeclarations = <D extends {name: string; hasBody: boolean}>(declarations: D[]): D[][] => {
+const groupOverloadDeclarations = <D extends {name: string; hasBody: boolean; description?: string | undefined}>(
+  declarations: D[],
+): Array<{winners: D[]; implementation: D | undefined}> => {
   const groups = new Map<string, D[]>()
   for (const declaration of declarations) {
     const group = groups.get(declaration.name)
@@ -1063,7 +1097,10 @@ const groupOverloadDeclarations = <D extends {name: string; hasBody: boolean}>(d
   }
   return [...groups.values()].map(group => {
     const signatures = group.filter(declaration => !declaration.hasBody)
-    return signatures.length > 0 ? signatures : group.slice(0, 1)
+    return {
+      winners: signatures.length > 0 ? signatures : group.slice(0, 1),
+      implementation: group.find(declaration => declaration.hasBody),
+    }
   })
 }
 
@@ -1097,23 +1134,25 @@ export const extractModuleClasses = (source: string): ExtractedClass[] => {
       if (hasConstructorParameters) continue
       if (hasBaseClass && !hasZeroArgConstructor) continue
       if (methodDeclarations.length === 0) continue
-      const methods = methodDeclarations.flatMap(({methodName, signatures}): ExtractedCommand[] => {
-        const overloads = signatures.flatMap(signature => {
-          const params = tryParseParams(`${name}.${methodName}`, signature.paramList)
-          return params ? [{description: signature.description, params}] : []
-        })
-        if (overloads.length === 0) return []
-        return [
-          {
-            name: methodName,
-            exportName: methodName,
-            default: false,
-            description: overloads[0].description,
-            params: overloads[0].params,
-            ...(overloads.length > 1 ? {overloads} : {}),
-          },
-        ]
-      })
+      const methods = methodDeclarations.flatMap(
+        ({methodName, signatures, implementationDescription}): ExtractedCommand[] => {
+          const overloads = signatures.flatMap(signature => {
+            const params = tryParseParams(`${name}.${methodName}`, signature.paramList)
+            return params ? [{description: signature.description, params}] : []
+          })
+          if (overloads.length === 0) return []
+          return [
+            {
+              name: methodName,
+              exportName: methodName,
+              default: false,
+              description: overloads[0].description,
+              params: overloads[0].params,
+              ...(overloads.length > 1 ? {overloads, implementationDescription} : {}),
+            },
+          ]
+        },
+      )
       if (methods.length === 0) continue
       classes.push({name, exportName, default: defaultExport, methods})
     }
@@ -1139,6 +1178,8 @@ const extractClassMethodDeclarations = (
     methodName: string
     /** one per body-less overload signature, or a single entry for a plain method - same rule as `groupOverloadDeclarations` */
     signatures: Array<{description: string | undefined; paramList: string}>
+    /** jsdoc of the overload implementation, when the method is overloaded */
+    implementationDescription: string | undefined
   }>
   hasConstructorParameters: boolean
   hasZeroArgConstructor: boolean
@@ -1203,9 +1244,10 @@ const extractClassMethodDeclarations = (
   return {
     hasConstructorParameters,
     hasZeroArgConstructor,
-    methodDeclarations: groupOverloadDeclarations(declarations).map(group => ({
-      methodName: group[0].name,
-      signatures: group.map(({description, paramList}) => ({description, paramList})),
+    methodDeclarations: groupOverloadDeclarations(declarations).map(({winners, implementation}) => ({
+      methodName: winners[0].name,
+      signatures: winners.map(({description, paramList}) => ({description, paramList})),
+      implementationDescription: implementation?.description,
     })),
   }
 }

--- a/tasks/module-overloads.md
+++ b/tasks/module-overloads.md
@@ -1,16 +1,18 @@
 ---
-status: in-progress
+status: implemented
 size: medium
 branch: module-overloads
+pr: https://github.com/mmkal/trpc-cli/pull/214
 ---
 
 # Support TS function overloads in module mode
 
 ## Status summary
 
-Spec fleshed out, implementation not started. Main pieces: extraction of all overload
-signatures (currently first-signature-wins), a first-match union validator with
-per-overload error reporting, per-overload usage lines in help, tests, README docs.
+Implemented and tested (full suite green). Overload signatures with single object
+parameters become alternate calling conventions: per-signature usage lines in help,
+merged flags with conflicts, first-match validation with closest-match-first errors.
+Remaining: nothing blocking; possible follow-ups listed at the bottom.
 
 ## Motivation
 
@@ -29,9 +31,9 @@ export function resize(params: {input: string; width?: number; height?: number; 
 }
 ```
 
-This should produce a `resize` command whose help shows both ways to call it, whose
-flags are the union of both signatures' flags, and whose validation accepts an
-invocation iff it matches at least one signature (checked in declaration order).
+This produces a `resize` command whose help shows both ways to call it, whose flags are
+the union of both signatures' flags, and whose validation accepts an invocation iff it
+matches at least one signature (checked in declaration order).
 
 Note the runtime function's *implementation* already dispatches on the input shape -
 that's what overload implementations do - so for object-parameter overloads the CLI
@@ -43,44 +45,56 @@ doesn't need to know which signature matched; it just passes the validated objec
   object(-like) parameter. This is where overloads make CLI sense: alternate *flag sets*.
   Signatures with positional parameters keep today's first-signature-wins behavior
   (positionals that differ per overload have no clean commander representation).
-  *Stretch*: overloads whose positional params are textually identical and only the
-  trailing options object differs could union just the trailing object - only do this if
-  it falls out naturally.
 - **Validation = first match wins, in declaration order** (mirrors TS overload
-  resolution). Build each signature's schema with the existing machinery, then combine
-  as `{anyOf: [...]}` with a hand-attached `~standard` validator that tries each
+  resolution). Each signature's schema is built with the existing machinery, then
+  combined as `{anyOf: [...]}` with a hand-attached `~standard` validator that tries each
   signature's validator in order and returns the first success.
 - **No-match errors: report each signature's error, closest match first.** "Closest" =
-  fewest issues (the user's "prioritise whichever error message is smaller" heuristic),
-  ties broken by declaration order. Label each group so the user can tell which calling
-  convention each error block refers to.
-- **Help: one usage line per overload**, derived from each signature's schema (required
-  flags as `--flag <value>`, optional as `[--flag <value>]`), with the overload's own
-  jsdoc as a trailing/adjacent description. Exact rendering mechanism (multi-line
-  `command.usage()` via the existing `meta.usage` array support vs `addHelpText`) to be
-  settled by snapshot tests - whichever reads best. The merged flags list stays as-is
-  (the existing union-of-objects flag derivation + `incompatiblePropertyPairs`
-  conflicts already handle it).
-- **Per-overload jsdoc**: the jsdoc on the *first* signature remains the command
-  description; each signature's jsdoc also describes its variant in the usage lines.
-  `@alias` etc. are only honored on the first signature's jsdoc.
-- **Class methods get the same treatment** - the extraction dedupe is duplicated in
-  `extractClassMethodDeclarations`; share the new logic.
-- **`{source, exports}` and file-backed modes both supported** - this is all
-  source-extraction + schema work, no loader changes.
+  fewest issues, ties broken by declaration order. Each line is labeled with the
+  signature's flags summary.
+- **Help: one usage line per overload** (required flags as `--flag <type>`, optional
+  bracketed, `true` literals and booleans as bare flags, literal unions as choices), with
+  the overload's jsdoc as an aligned trailing `# comment`. Rendered via the existing
+  `meta.usage` array support, plus a small index.ts improvement that aligns multi-line
+  usage under `Usage: ` with the full command prefix repeated (previously continuation
+  lines rendered unindented at column 0 - benefits every meta.usage array user).
+- **Per-overload jsdoc**: the first signature's jsdoc remains the command description;
+  each signature's jsdoc (first line) becomes its usage line's comment. `@alias` is only
+  honored on the first signature's jsdoc.
+- **Class methods get the same treatment** via a shared `groupOverloadDeclarations`.
+- **Shared-flag metadata propagation**: the union flag-merge keeps the *last* occurrence
+  of each property, so descriptions/`@alias` declared on one signature are copied onto
+  same-named undocumented properties in other signatures (cosmetic only).
 
 ## Checklist
 
-- [ ] extraction: collect *all* body-less overload signatures per export name (ordered), not just the first; implementation signature still excluded when signatures exist
-- [ ] procedure building: when ≥2 signatures and all are single-object params, build per-signature schemas and combine into a first-match union with hand-attached `~standard` validator
-- [ ] fallback: any signature with positionals (or otherwise non-object) → current first-signature-wins behavior
-- [ ] no-match error message: per-signature error groups, fewest-issues-first, clearly labeled
-- [ ] help: per-overload usage lines with per-overload jsdoc descriptions
-- [ ] class methods: same overload support
-- [ ] tests in test/typebox-module-commands.test.ts (help snapshot, first-match runtime dispatch, error output, class methods, jsdoc per overload); update the two existing first-overload-wins tests
-- [ ] README docs for module mode overloads (via readme-codegen if applicable)
-- [ ] PR note: feasibility of equivalent support in trpc/orpc mode
+- [x] extraction: collect *all* body-less overload signatures per export name (ordered) _`groupOverloadDeclarations` in module-commands.ts, shared by functions and class methods; implementation signature still excluded when signatures exist_
+- [x] procedure building: ≥2 single-object-param signatures → first-match union with hand-attached `~standard` validator _`buildOverloadedProcedure` + `validateOverloads`_
+- [x] fallback: any signature with positionals (or otherwise non-object/unparseable) → first-signature-wins _`buildOverloadedProcedure` returns undefined, `buildProcedure` falls through_
+- [x] no-match error message: per-signature error lines, fewest-issues-first, labeled with flags summary _single multi-line issue rendered by the existing prettifier_
+- [x] help: per-overload usage lines with per-overload jsdoc comments _`overloadFlagsSummary` + meta.usage array + index.ts multi-line usage alignment_
+- [x] class methods: same overload support _`extractClassMethodDeclarations` returns signature groups_
+- [x] tests _new: alternate-calling-conventions (help snapshot, dispatch, conflicts, no-match errors), named types + required literals, class method overloads; updated: the two first-overload-wins pins (one became the feature test, the positional one stays as the fallback pin)_
+- [x] README docs _overloads example with console output in the module-mode section; limitations bullet rewritten_
+- [x] PR note: feasibility of equivalent support in trpc/orpc mode _in PR body_
 
 ## Implementation notes
 
-(log as work happens)
+- The existing union-of-objects machinery did most of the heavy lifting: `flattenedProperties`
+  merges `anyOf` flags, `incompatiblePropertyPairs` + commander `conflicts` already reject
+  mixing flags across signatures, and `parse-procedure` accepts anyOf-of-objects as a flags
+  schema. The new work was extraction (keep all signatures), the ordered first-match
+  validator with grouped errors, usage-line generation, and metadata propagation.
+- The vendored typebox `~standard.validate` is synchronous and passes values through
+  unchanged (no coercion/defaults), so first-match checking is purely about error
+  reporting/order semantics - `validateOverloads` throws if a variant validator ever
+  returns a Promise (it can't today).
+- Overloads of a *scalar* parameter (e.g. `(x: string)` / `(x: number)`) also fall back to
+  first-signature: alternate positional layouts aren't representable.
+
+## Possible follow-ups (not done)
+
+- Overloads whose positional params are textually identical, differing only in the
+  trailing options object, could union just the trailing object.
+- trpc/orpc mode: unions of objects already work there (`z.union([...])`); what's missing
+  is only the per-variant usage lines/descriptions presentation. See PR note.

--- a/tasks/module-overloads.md
+++ b/tasks/module-overloads.md
@@ -92,6 +92,20 @@ doesn't need to know which signature matched; it just passes the validated objec
 - Overloads of a *scalar* parameter (e.g. `(x: string)` / `(x: number)`) also fall back to
   first-signature: alternate positional layouts aren't representable.
 
+## Review feedback round 1 (2026-07-08)
+
+- "misleadingly universal" description: the first signature's jsdoc no longer poses as the
+  command description. Precedence now: implementation-signature jsdoc (the new home for an
+  overall description) > signatures' distinct descriptions joined with ' / '. `@alias` is
+  honored wherever declared (implementation or any signature).
+- Flag descriptions now advertise incompatibilities (`Do not use with: --scale`), derived
+  from the same `incompatiblePropertyPairs` that powers commander `conflicts`. Implemented
+  generically in index.ts, so zod/trpc union inputs get it too (migrations fixture
+  snapshots updated accordingly).
+- A flag documented *differently* across signatures shows every distinct description
+  joined with ' / ' (previously last-write-wins). Jsdoc declared in only one signature
+  already propagated; now pinned by tests.
+
 ## Possible follow-ups (not done)
 
 - Overloads whose positional params are textually identical, differing only in the

--- a/tasks/module-overloads.md
+++ b/tasks/module-overloads.md
@@ -1,0 +1,86 @@
+---
+status: in-progress
+size: medium
+branch: module-overloads
+---
+
+# Support TS function overloads in module mode
+
+## Status summary
+
+Spec fleshed out, implementation not started. Main pieces: extraction of all overload
+signatures (currently first-signature-wins), a first-match union validator with
+per-overload error reporting, per-overload usage lines in help, tests, README docs.
+
+## Motivation
+
+Module mode currently detects TS overload signatures but throws away all but the first
+(see the dedupe in `extractModuleCommands`, with tests pinning that behavior). Overloads
+are the natural TypeScript idiom for "this function has two alternate calling
+conventions", which maps directly to a CLI command with two alternate invocation forms:
+
+```ts
+/** resize by explicit dimensions */
+export function resize(params: {input: string; width: number; height: number}): Promise<string>
+/** resize by scale factor, preserving aspect ratio */
+export function resize(params: {input: string; scale: number}): Promise<string>
+export function resize(params: {input: string; width?: number; height?: number; scale?: number}) {
+  // runtime implementation handles both shapes
+}
+```
+
+This should produce a `resize` command whose help shows both ways to call it, whose
+flags are the union of both signatures' flags, and whose validation accepts an
+invocation iff it matches at least one signature (checked in declaration order).
+
+Note the runtime function's *implementation* already dispatches on the input shape -
+that's what overload implementations do - so for object-parameter overloads the CLI
+doesn't need to know which signature matched; it just passes the validated object.
+
+## Design decisions (made autonomously - flagging assumptions)
+
+- **Scope: flags-only overloads.** Each participating signature must be a single
+  object(-like) parameter. This is where overloads make CLI sense: alternate *flag sets*.
+  Signatures with positional parameters keep today's first-signature-wins behavior
+  (positionals that differ per overload have no clean commander representation).
+  *Stretch*: overloads whose positional params are textually identical and only the
+  trailing options object differs could union just the trailing object - only do this if
+  it falls out naturally.
+- **Validation = first match wins, in declaration order** (mirrors TS overload
+  resolution). Build each signature's schema with the existing machinery, then combine
+  as `{anyOf: [...]}` with a hand-attached `~standard` validator that tries each
+  signature's validator in order and returns the first success.
+- **No-match errors: report each signature's error, closest match first.** "Closest" =
+  fewest issues (the user's "prioritise whichever error message is smaller" heuristic),
+  ties broken by declaration order. Label each group so the user can tell which calling
+  convention each error block refers to.
+- **Help: one usage line per overload**, derived from each signature's schema (required
+  flags as `--flag <value>`, optional as `[--flag <value>]`), with the overload's own
+  jsdoc as a trailing/adjacent description. Exact rendering mechanism (multi-line
+  `command.usage()` via the existing `meta.usage` array support vs `addHelpText`) to be
+  settled by snapshot tests - whichever reads best. The merged flags list stays as-is
+  (the existing union-of-objects flag derivation + `incompatiblePropertyPairs`
+  conflicts already handle it).
+- **Per-overload jsdoc**: the jsdoc on the *first* signature remains the command
+  description; each signature's jsdoc also describes its variant in the usage lines.
+  `@alias` etc. are only honored on the first signature's jsdoc.
+- **Class methods get the same treatment** - the extraction dedupe is duplicated in
+  `extractClassMethodDeclarations`; share the new logic.
+- **`{source, exports}` and file-backed modes both supported** - this is all
+  source-extraction + schema work, no loader changes.
+
+## Checklist
+
+- [ ] extraction: collect *all* body-less overload signatures per export name (ordered), not just the first; implementation signature still excluded when signatures exist
+- [ ] procedure building: when ≥2 signatures and all are single-object params, build per-signature schemas and combine into a first-match union with hand-attached `~standard` validator
+- [ ] fallback: any signature with positionals (or otherwise non-object) → current first-signature-wins behavior
+- [ ] no-match error message: per-signature error groups, fewest-issues-first, clearly labeled
+- [ ] help: per-overload usage lines with per-overload jsdoc descriptions
+- [ ] class methods: same overload support
+- [ ] tests in test/typebox-module-commands.test.ts (help snapshot, first-match runtime dispatch, error output, class methods, jsdoc per overload); update the two existing first-overload-wins tests
+- [ ] README docs for module mode overloads (via readme-codegen if applicable)
+- [ ] PR note: feasibility of equivalent support in trpc/orpc mode
+
+## Implementation notes
+
+(log as work happens)

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -382,8 +382,10 @@ test('migrations incompatible flags', async () => {
     Apply migrations. By default all pending migrations will be applied.
 
     Options:
-      --to [string]    Mark migrations up to this one as exectued
-      --step [number]  Mark this many migrations as executed; Exclusive minimum: 0
+      --to [string]    Mark migrations up to this one as exectued; Do not use with:
+                       --step
+      --step [number]  Mark this many migrations as executed; Exclusive minimum: 0;
+                       Do not use with: --to
       -h, --help       display help for command
     "
   `)

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -107,7 +107,7 @@ test('migrations toJSON', async () => {
               "negate": false,
               "variadic": false,
               "flags": "--to [string]",
-              "description": "Mark migrations up to this one as exectued",
+              "description": "Mark migrations up to this one as exectued; Do not use with: --step",
               "attributeName": "to"
             },
             {
@@ -117,7 +117,7 @@ test('migrations toJSON', async () => {
               "negate": false,
               "variadic": false,
               "flags": "--step [number]",
-              "description": "Mark this many migrations as executed; Exclusive minimum: 0",
+              "description": "Mark this many migrations as executed; Exclusive minimum: 0; Do not use with: --to",
               "attributeName": "step"
             }
           ],

--- a/test/typebox-module-commands.test.ts
+++ b/test/typebox-module-commands.test.ts
@@ -684,29 +684,138 @@ test('module positionals: boolean and literal-union positionals', async () => {
   await expect(runWith(params, ['set', 'nope', 'true'])).rejects.toThrowError(/nope/)
 })
 
-test('module commands: overloaded functions use the first overload signature', async () => {
+test('module commands: overloaded functions become alternate calling conventions', async () => {
   const params = {
-    // TS overloads extract once per declaration. The *implementation* signature is typically widened
-    // (`options: any`) - using it would produce a misleading error. TS resolves calls against the overload
-    // signatures in order, so the FIRST signature is the primary documented shape and becomes the command's
-    // calling convention; the implementation and later overloads are ignored.
+    // TS overloads extract once per declaration: the body-less *signatures* first, the *implementation* (typically
+    // widened, e.g. `params: any`) last. Every signature becomes a way to call the command: help shows one usage
+    // line per signature (with its jsdoc as a trailing comment), the flags list is the union of all signatures'
+    // flags, and validation checks each signature in declaration order, passing the first match to the function.
     source: `
-      export function f(options: {mode: 'a'}): string
-      export function f(options: {mode: 'b'}): number
-      export function f(options: any) { return options.mode }
+      /** resize by explicit dimensions */
+      export function resize(params: {
+        /** path to the input image */
+        input: string
+        width: number
+        height: number
+      }): Promise<string>
+      /** resize by scale factor, preserving aspect ratio */
+      export function resize(params: {input: string; scale: number}): Promise<string>
+      export function resize(params: any) {
+        return 'resized'
+      }
     `,
-    exports: {f: (options: any) => options.mode},
+    exports: {
+      resize: (input: any) =>
+        'scale' in input
+          ? `resized ${input.input} by ${input.scale}x`
+          : `resized ${input.input} to ${input.width}x${input.height}`,
+    },
   }
-  expect(await runWith(params, ['f', '--mode', 'a'])).toMatchInlineSnapshot(`"a"`)
-  // the second overload is ignored, so 'b' is rejected - the CLI presents exactly one calling convention
-  await expect(runWith(params, ['f', '--mode', 'b'])).rejects.toMatchInlineSnapshot(`
-    CLI exited with code 1
-      Caused by: Error: Invalid input: ✖ must be equal to constant → at mode
+
+  expect(await runWith({...params, name: 'imgtool'}, ['resize', '--help'])).toMatchInlineSnapshot(`
+    "Usage: imgtool resize --input <string> --width <number> --height <number>  # resize by explicit dimensions
+           imgtool resize --input <string> --scale <number>                    # resize by scale factor, preserving aspect ratio
+
+    resize by explicit dimensions
+
+    Options:
+      --input [string]   path to the input image
+      --width [number]
+      --height [number]
+      --scale [number]
+      -h, --help         display help for command
+    "
   `)
+
+  // each signature is dispatched by first match, in declaration order - the implementation branches on shape
+  expect(await runWith(params, ['resize', '--input', 'a.png', '--width', '100', '--height', '50'])).toBe(
+    'resized a.png to 100x50',
+  )
+  expect(await runWith(params, ['resize', '--input', 'a.png', '--scale', '0.5'])).toBe('resized a.png by 0.5x')
+
+  // flags that never appear in the same signature are conflicting - commander catches the mix before validation
+  await expect(runWith(params, ['resize', '--input', 'a.png', '--width', '100', '--scale', '2'])).rejects.toThrow(
+    /'--width \[number]' cannot be used with option '--scale \[number]'/,
+  )
+
+  // matching no signature reports each signature's issues - closest match (fewest issues) first
+  await expect(runWith(params, ['resize', '--input', 'a.png'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: Error: Invalid input: ✖ matched none of the 2 ways to call this command:
+      --input <string> --width <number> --height <number>: must have required properties width, height
+      --input <string> --scale <number>: must have required properties scale
+  `)
+})
+
+test('module commands: overload signatures can use named types and required literals', async () => {
+  const params = {
+    // pnpm-install-style: a required `global: true` literal is the discriminator for the second calling
+    // convention, and shows in its usage line as a bare required flag
+    source: `
+      type LocalInstall = {
+        /** the package to install */
+        name: string
+        dev?: boolean
+      }
+      type GlobalInstall = {name: string; global: true; saveDir?: string}
+
+      export function install(params: LocalInstall): Promise<string>
+      export function install(params: GlobalInstall): Promise<string>
+      export function install(params: any) {
+        return 'installed'
+      }
+    `,
+    exports: {
+      install: (input: any) => `installed ${input.name}${input.global ? ' globally' : ''}`,
+    },
+  }
+  const help = await runWith({...params, name: 'mypm'}, ['install', '--help'])
+  expect(help).toContain('mypm install --name <string> [--dev]')
+  expect(help).toContain('mypm install --name <string> --global [--save-dir <string>]')
+  expect(help).toContain('the package to install') // property jsdoc survives the flag merge across signatures
+  expect(await runWith(params, ['install', '--name', 'left-pad', '--global'])).toBe('installed left-pad globally')
+  expect(await runWith(params, ['install', '--name', 'left-pad'])).toBe('installed left-pad')
+})
+
+test('module commands: class method overloads become alternate calling conventions', async () => {
+  const params = {
+    source: `
+      export class Auth {
+        /** log in with a personal access token */
+        login(options: {token: string}): string
+        /** log in with a username and password */
+        login(options: {username: string; password: string}): string
+        login(options: any) {
+          return 'logged in'
+        }
+      }
+    `,
+    exports: {
+      Auth: class {
+        login(options: any) {
+          return 'token' in options ? 'logged in with token' : `logged in as ${options.username}`
+        }
+      },
+    },
+  }
+  const help = await runWith(params, ['auth', 'login', '--help'])
+  // usage lines repeat the full nested command prefix and align the jsdoc comments across signatures
+  expect(help).toContain(
+    'Usage: program auth login --token <string>                         # log in with a personal access token',
+  )
+  expect(help).toContain(
+    '       program auth login --username <string> --password <string>  # log in with a username and password',
+  )
+  expect(await runWith(params, ['auth', 'login', '--token', 'xyz'])).toBe('logged in with token')
+  expect(await runWith(params, ['auth', 'login', '--username', 'amy', '--password', 'hunter2'])).toBe(
+    'logged in as amy',
+  )
 })
 
 test('module positionals: overloaded multi-parameter functions use the first overload signature', async () => {
   const params = {
+    // alternate calling conventions are only derived for single-object-parameter signatures - commander has no way
+    // to present alternate positional layouts, so overloads with positionals fall back to the first signature
     source: `
       /** greet someone */
       export function greet(name: string, options?: {shout?: boolean}): string

--- a/test/typebox-module-commands.test.ts
+++ b/test/typebox-module-commands.test.ts
@@ -716,13 +716,13 @@ test('module commands: overloaded functions become alternate calling conventions
     "Usage: imgtool resize --input <string> --width <number> --height <number>  # resize by explicit dimensions
            imgtool resize --input <string> --scale <number>                    # resize by scale factor, preserving aspect ratio
 
-    resize by explicit dimensions
+    resize by explicit dimensions / resize by scale factor, preserving aspect ratio
 
     Options:
       --input [string]   path to the input image
-      --width [number]
-      --height [number]
-      --scale [number]
+      --width [number]   Do not use with: --scale
+      --height [number]  Do not use with: --scale
+      --scale [number]   Do not use with: --height, --width
       -h, --help         display help for command
     "
   `)
@@ -785,6 +785,7 @@ test('module commands: class method overloads become alternate calling conventio
         login(options: {token: string}): string
         /** log in with a username and password */
         login(options: {username: string; password: string}): string
+        /** authenticate with the service */
         login(options: any) {
           return 'logged in'
         }
@@ -806,10 +807,51 @@ test('module commands: class method overloads become alternate calling conventio
   expect(help).toContain(
     '       program auth login --username <string> --password <string>  # log in with a username and password',
   )
+  // the *implementation* signature's jsdoc describes the command as a whole (each overload jsdoc only describes
+  // its own calling convention, so none of them can honestly claim the top-level description slot)
+  expect(help).toContain('authenticate with the service')
   expect(await runWith(params, ['auth', 'login', '--token', 'xyz'])).toBe('logged in with token')
   expect(await runWith(params, ['auth', 'login', '--username', 'amy', '--password', 'hunter2'])).toBe(
     'logged in as amy',
   )
+})
+
+test('module commands: overload flag jsdoc - repeated, differing, and signature-specific', async () => {
+  const params = {
+    source: `
+      /** fetch from a URL */
+      export function grab(options: {
+        /** URL of the resource */
+        source: string
+        /** HTTP timeout in ms */
+        timeoutMs?: number
+      }): string
+      /** read from disk */
+      export function grab(options: {
+        /** path to a local file */
+        source: string
+        encoding?: 'utf8' | 'base64'
+      }): string
+      export function grab(options: any) {
+        return 'grabbed'
+      }
+    `,
+    exports: {grab: (options: any) => `grabbed ${options.source}`},
+  }
+  expect(await runWith({...params, name: 'grabber'}, ['grab', '--help'])).toMatchInlineSnapshot(`
+    "Usage: grabber grab --source <string> [--timeout-ms <number>]     # fetch from a URL
+           grabber grab --source <string> [--encoding <utf8|base64>]  # read from disk
+
+    fetch from a URL / read from disk
+
+    Options:
+      --source [string]      URL of the resource / path to a local file
+      --timeout-ms [number]  HTTP timeout in ms; Do not use with: --encoding
+      --encoding [string]    Do not use with: --timeout-ms (choices: "utf8",
+                             "base64")
+      -h, --help             display help for command
+    "
+  `)
 })
 
 test('module positionals: overloaded multi-parameter functions use the first overload signature', async () => {


### PR DESCRIPTION
Module mode currently detects TS overload signatures but only uses the first one. This PR turns each overload signature into an alternate calling convention for the command - overloads being the natural TypeScript idiom for "this function can be called in two different ways":

```ts
// commands.ts
/** resize by explicit dimensions */
export function resize(params: {input: string; width: number; height: number}): Promise<string>
/** resize by scale factor, preserving aspect ratio */
export function resize(params: {input: string; scale: number}): Promise<string>
export function resize(params: any) {
  // the implementation dispatches on the input's shape, as overload implementations always do
}
```

```console
$ mycli resize --help
Usage: mycli resize --input <string> --width <number> --height <number>  # resize by explicit dimensions
       mycli resize --input <string> --scale <number>                    # resize by scale factor, preserving aspect ratio

resize by explicit dimensions

Options:
  --input [string]   path to the input image
  --width [number]
  --height [number]
  --scale [number]
  -h, --help         display help for command

$ mycli resize --input a.png --scale 0.5     # matches signature 2, function gets the validated object
$ mycli resize --input a.png --width 5 --scale 2
error: option '--width [number]' cannot be used with option '--scale [number]'

$ mycli resize --input a.png
Invalid input: ✖ matched none of the 2 ways to call this command:
  --input <string> --width <number> --height <number>: must have required properties width, height
  --input <string> --scale <number>: must have required properties scale
```

How it works:

- **Extraction**: all body-less overload signatures are kept (in declaration order) instead of just the first; the implementation signature is still ignored, so a widened `params: any` implementation can't poison the command. Shared between functions and class methods.
- **Flags**: each signature's schema is built with the existing machinery and combined as `anyOf` - the existing union-of-objects flag derivation merges the flag lists, and `incompatiblePropertyPairs` + commander `conflicts` already reject mixing flags that never co-occur in a signature. Descriptions/`@alias` documented on one signature are propagated to the same-named flag in others (the merge otherwise keeps the last occurrence).
- **Validation**: a hand-attached `~standard` validator checks each signature in declaration order (mirroring TS overload resolution) and passes the first match to the function - which needs no "which overload" marker, since overload implementations dispatch on shape anyway. No-match errors list each signature's issues, closest match (fewest issues) first.
- **Help**: one usage line per signature with its jsdoc as an aligned `#` comment, via `meta.usage`. A small `index.ts` improvement makes multi-line `meta.usage` arrays render aligned under `Usage: ` with the full command prefix repeated (previously continuation lines rendered unindented at column 0) - this benefits anyone passing a `usage` array in any mode.

Scope: only overloads where **every** signature takes a single object(-like) parameter participate. Signatures with positional parameters keep the previous first-signature-wins behavior, since commander has no way to present alternate positional layouts for one command (pinned by the existing `greet` test).

### Would this be worthwhile in trpc/orpc mode?

Mostly it already exists there: overloads are a TS-syntax concept with no runtime schema equivalent, and the natural way to express "two calling conventions" with zod et al is `z.union([z.object(...), z.object(...)])` - which trpc-cli already supports (merged flags, conflicts, union validation). What trpc/orpc mode *doesn't* get is the presentation layer added here: per-variant usage lines with per-variant descriptions and the closest-match-first error grouping. Adding that would mean detecting top-level unions in `parse-procedure` and deriving usage lines + a variant-aware validator wrapper from the JSON schema (using each branch's `description` as the comment). Moderate effort, no new concepts, and it would make the two modes consistent - worthwhile as a follow-up if union-input CLIs turn out to be common, but not tricky enough to block this PR on.

Task file: `tasks/module-overloads.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)