### PR TITLE
Support Valibot CLI metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ To use positional arguments _and_ options, there are two approaches:
 
 **1) Using input schema metadata (recommended)**
 
-Use `z.string().meta({positional: true})`. This is available on zod v4, and arktype via `type('string').configure({positional: true})`:
+Use `z.string().meta({positional: true})`. This is available on zod v4, Valibot via `v.pipe(v.string(), v.metadata({positional: true}))`, and arktype via `type('string').configure({positional: true})`:
 
 ```ts
 t.router({
@@ -546,6 +546,28 @@ const router = t.router({
 const cli = createCli({router})
 
 cli.run() // e.g. `mycli add 1 2`
+```
+
+Valibot `v.metadata(...)` values are understood for trpc-cli-specific fields like `alias`, `positional`, `hidden`, and `negatable`:
+
+```ts
+const router = t.router({
+  install: t.procedure
+    .input(
+      v.object({
+        cwd: v.pipe(v.string(), v.metadata({positional: true})),
+        frozenLockfile: v.pipe(
+          v.optional(v.boolean()),
+          v.metadata({alias: 'f', negatable: true}),
+        ),
+      }),
+    )
+    .query(({input}) => JSON.stringify(input)),
+})
+
+const cli = createCli({router})
+
+cli.run() // e.g. `mycli install /repo -f`
 ```
 
 ### effect

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -275,6 +275,145 @@ export function toJsonSchema(input: unknown, dependencies: Dependencies): Result
 
 // #region vendor specific stuff
 
+const valibotCliMetaKeys = ['alias', 'positional', 'hidden', 'negatable'] as const
+
+type ValibotCliMeta = Partial<Record<(typeof valibotCliMetaKeys)[number], unknown>>
+type ValibotGetMetadata = ((schema: unknown) => Record<string, unknown>) | undefined
+type ValibotSchemaLike = {
+  type?: unknown
+  wrapped?: unknown
+  entries?: unknown
+  item?: unknown
+  items?: unknown
+}
+type ValibotModule = {
+  object: (entries: {child: unknown}) => unknown
+  getMetadata?: unknown
+}
+
+// @valibot/to-json-schema does not include custom v.metadata(...) values, so copy over the CLI-specific fields
+// after conversion while preserving the JSON Schema shape emitted by the converter.
+const getValibotCliMeta = (getMetadata: ValibotGetMetadata, schema: unknown): ValibotCliMeta => {
+  if (!getMetadata || !schema) return {}
+
+  try {
+    const metadata = getMetadata(schema)
+    const cliMeta: ValibotCliMeta = {}
+
+    for (const key of valibotCliMetaKeys) {
+      if (key in metadata) cliMeta[key] = metadata[key]
+    }
+
+    return cliMeta
+  } catch {
+    return {}
+  }
+}
+
+const getValibotSchemaChain = (schema: unknown): unknown[] => {
+  const chain: unknown[] = []
+  const seen = new Set<unknown>()
+  let current = schema
+
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    chain.push(current)
+    seen.add(current)
+
+    const wrapped = (current as ValibotSchemaLike).wrapped
+    if (!wrapped) break
+    current = wrapped
+  }
+
+  return chain
+}
+
+const unwrapValibotSchema = (schema: unknown): unknown => {
+  return getValibotSchemaChain(schema).at(-1) ?? schema
+}
+
+const getDeepValibotCliMeta = (getMetadata: ValibotGetMetadata, schema: unknown): ValibotCliMeta => {
+  const cliMeta: ValibotCliMeta = {}
+  const chain = getValibotSchemaChain(schema)
+
+  for (let index = chain.length - 1; index >= 0; index--) {
+    Object.assign(cliMeta, getValibotCliMeta(getMetadata, chain[index]))
+  }
+
+  return cliMeta
+}
+
+const assignValibotCliMeta = (jsonSchema: JSONSchema7, cliMeta: ValibotCliMeta) => {
+  if (Object.keys(cliMeta).length > 0) Object.assign(jsonSchema, cliMeta)
+}
+
+const primaryJsonSchemaShape = (jsonSchema: JSONSchema7): JSONSchema7 => {
+  if (Array.isArray(jsonSchema.anyOf)) {
+    const nonNot = jsonSchema.anyOf.find(subSchema => {
+      return (
+        subSchema &&
+        typeof subSchema === 'object' &&
+        !('not' in subSchema && Object.keys(subSchema).join(',') === 'not')
+      )
+    })
+
+    if (nonNot && typeof nonNot === 'object') return {...jsonSchema, ...nonNot}
+  }
+
+  return jsonSchema
+}
+
+const applyValibotCliMetadata = (getMetadata: ValibotGetMetadata, schema: unknown, jsonSchema: JSONSchema7) => {
+  assignValibotCliMeta(jsonSchema, getDeepValibotCliMeta(getMetadata, schema))
+
+  const unwrapped = unwrapValibotSchema(schema) as ValibotSchemaLike
+  const shape = primaryJsonSchemaShape(jsonSchema)
+
+  if (unwrapped.type === 'object' && unwrapped.entries && typeof unwrapped.entries === 'object' && shape.properties) {
+    const required = Array.isArray(shape.required) ? new Set(shape.required) : null
+    for (const [key, entrySchema] of Object.entries(unwrapped.entries)) {
+      const propertyJson = shape.properties[key]
+      if (propertyJson && typeof propertyJson === 'object') {
+        if (required && !required.has(key)) Object.assign(propertyJson, {optional: true})
+        applyValibotCliMetadata(getMetadata, entrySchema, propertyJson)
+      }
+    }
+  }
+
+  if (unwrapped.type === 'array' && unwrapped.item) {
+    const itemsJson = shape.items
+    if (itemsJson && typeof itemsJson === 'object' && !Array.isArray(itemsJson)) {
+      applyValibotCliMetadata(getMetadata, unwrapped.item, itemsJson)
+    }
+  }
+
+  if (unwrapped.type === 'tuple' && Array.isArray(unwrapped.items)) {
+    const jsonTupleItems =
+      (shape as JSONSchema7 & {prefixItems?: JSONSchema7[]}).prefixItems ||
+      (Array.isArray(shape.items) ? shape.items : [])
+
+    unwrapped.items.forEach((itemSchema, index) => {
+      const itemJson = jsonTupleItems[index]
+      if (itemJson && typeof itemJson === 'object') applyValibotCliMetadata(getMetadata, itemSchema, itemJson)
+    })
+  }
+}
+
+const convertValibotToJsonSchema = (
+  input: unknown,
+  valibot: ValibotModule,
+  valibotToJsonSchema: (input: unknown, options?: {errorMode?: 'throw' | 'ignore' | 'warn'}) => JSONSchema7,
+) => {
+  const parent = valibotToJsonSchema(valibot.object({child: input}), {
+    errorMode: 'ignore',
+  })
+  const child = parent.properties!.child as JSONSchema7
+  const result = parent.required?.length === 0 ? Object.assign(child, {optional: true}) : child
+  const getMetadata =
+    typeof valibot.getMetadata === 'function' ? (valibot.getMetadata as ValibotGetMetadata) : undefined
+  applyValibotCliMetadata(getMetadata, input, result)
+  return result
+}
+
 /** `Record<standard-schema vendor id, function that converts the input to JSON schema>` */
 const getJsonSchemaConverters = (dependencies: Dependencies) => {
   return {
@@ -324,11 +463,11 @@ const getJsonSchemaConverters = (dependencies: Dependencies) => {
         return valibotToJsonSchema(input as never)
       }
       const v = getModule(valibotOrError)
-      const parent = valibotToJsonSchema(v.object({child: input as import('valibot').StringSchema<undefined>}), {
-        errorMode: 'ignore',
-      })
-      const child = parent.properties!.child as JSONSchema7
-      return parent.required?.length === 0 ? Object.assign(child, {optional: true}) : child
+      return convertValibotToJsonSchema(
+        input,
+        v as ValibotModule,
+        valibotToJsonSchema as (input: unknown, options?: {errorMode?: 'throw' | 'ignore' | 'warn'}) => JSONSchema7,
+      )
     },
     effect: (input: unknown) => {
       const effect = dependencies.effect || getModule(effectOrError)

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -296,18 +296,14 @@ type ValibotModule = {
 const getValibotCliMeta = (getMetadata: ValibotGetMetadata, schema: unknown): ValibotCliMeta => {
   if (!getMetadata || !schema) return {}
 
-  try {
-    const metadata = getMetadata(schema)
-    const cliMeta: ValibotCliMeta = {}
+  const metadata = getMetadata(schema)
+  const cliMeta: ValibotCliMeta = {}
 
-    for (const key of valibotCliMetaKeys) {
-      if (key in metadata) cliMeta[key] = metadata[key]
-    }
-
-    return cliMeta
-  } catch {
-    return {}
+  for (const key of valibotCliMetaKeys) {
+    if (key in metadata) cliMeta[key] = metadata[key]
   }
+
+  return cliMeta
 }
 
 const getValibotSchemaChain = (schema: unknown): unknown[] => {
@@ -346,14 +342,15 @@ const assignValibotCliMeta = (jsonSchema: JSONSchema7, cliMeta: ValibotCliMeta) 
   if (Object.keys(cliMeta).length > 0) Object.assign(jsonSchema, cliMeta)
 }
 
+const isEmptyNotSchema = (jsonSchema: JSONSchema7): boolean => {
+  const not = jsonSchema.not
+  return Object.keys(jsonSchema).length === 1 && !!not && typeof not === 'object' && Object.keys(not).length === 0
+}
+
 const primaryJsonSchemaShape = (jsonSchema: JSONSchema7): JSONSchema7 => {
   if (Array.isArray(jsonSchema.anyOf)) {
     const nonNot = jsonSchema.anyOf.find(subSchema => {
-      return (
-        subSchema &&
-        typeof subSchema === 'object' &&
-        !('not' in subSchema && Object.keys(subSchema).join(',') === 'not')
-      )
+      return subSchema && typeof subSchema === 'object' && !isEmptyNotSchema(subSchema)
     })
 
     if (nonNot && typeof nonNot === 'object') return {...jsonSchema, ...nonNot}

--- a/test/valibot.test.ts
+++ b/test/valibot.test.ts
@@ -592,6 +592,144 @@ test('defaults and negations', async () => {
 })
 // codegen:end
 
+test('alias via valibot metadata', async () => {
+  const router = t.router({
+    test: t.procedure
+      .input(
+        v.object({
+          foo: v.pipe(v.optional(v.string()), v.metadata({alias: 'f'})),
+          bar: v.optional(v.pipe(v.string(), v.metadata({alias: 'bb'}))),
+          abc: v.pipe(v.optional(v.string()), v.metadata({alias: '--something-else-entirely'})),
+        }),
+      )
+      .mutation(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['test', '--foo', 'hello'])).toMatchInlineSnapshot(`"{"foo":"hello"}"`)
+  expect(await run(router, ['test', '-f', 'hello'])).toMatchInlineSnapshot(`"{"foo":"hello"}"`)
+  expect(await run(router, ['test', '--bar', 'hello'])).toMatchInlineSnapshot(`"{"bar":"hello"}"`)
+  expect(await run(router, ['test', '--bb', 'hello'])).toMatchInlineSnapshot(`"{"bar":"hello"}"`)
+  expect(await run(router, ['test', '--something-else-entirely', 'hello'])).toMatchInlineSnapshot(`"{"abc":"hello"}"`)
+})
+
+test('positional via valibot metadata', async () => {
+  const router = t.router({
+    test: t.procedure
+      .input(
+        v.object({
+          foo: v.pipe(v.string(), v.metadata({positional: true})),
+          bar: v.optional(v.pipe(v.number(), v.metadata({positional: true}))),
+          abc: v.optional(v.string()),
+        }),
+      )
+      .mutation(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['test', 'hello'])).toMatchInlineSnapshot(`"{"foo":"hello"}"`)
+  expect(await run(router, ['test', 'hello', '1'])).toMatchInlineSnapshot(`"{"foo":"hello","bar":1}"`)
+  expect(await run(router, ['test', 'hello', '1', '--abc', '2'])).toMatchInlineSnapshot(
+    `"{"foo":"hello","bar":1,"abc":"2"}"`,
+  )
+})
+
+test('merged positional via valibot metadata', async () => {
+  const router = t.router({
+    test: t.procedure
+      .input(
+        v.object({
+          foo: v.pipe(v.string(), v.metadata({positional: true})),
+          bar: v.optional(v.pipe(v.number(), v.metadata({positional: true}))),
+          abc: v.optional(v.string()),
+        }),
+      )
+      .input(
+        v.object({
+          hello: v.pipe(v.string(), v.metadata({positional: true})),
+        }),
+      )
+      .mutation(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['test', 'ff', '1', 'hh'])).toMatchInlineSnapshot(`"{"foo":"ff","bar":1,"hello":"hh"}"`)
+})
+
+test('array positional via valibot metadata', async () => {
+  const router = t.router({
+    stringArray: t.procedure
+      .input(
+        v.object({
+          foo: v.pipe(v.array(v.string()), v.metadata({positional: true})),
+        }),
+      )
+      .mutation(({input}) => JSON.stringify(input)),
+    numberAndStringArray: t.procedure
+      .input(
+        v.object({
+          bar: v.pipe(v.number(), v.metadata({positional: true})),
+          foo: v.pipe(v.array(v.string()), v.metadata({positional: true})),
+        }),
+      )
+      .mutation(({input}) => JSON.stringify(input)),
+  })
+
+  expect(await run(router, ['string-array', 'hello', 'goodbye'])).toMatchInlineSnapshot(`"{"foo":["hello","goodbye"]}"`)
+  expect(await run(router, ['number-and-string-array', '123', 'hello', 'goodbye'])).toMatchInlineSnapshot(
+    `"{"bar":123,"foo":["hello","goodbye"]}"`,
+  )
+})
+
+test('hidden option via valibot metadata', async () => {
+  const router = t.router({
+    test: t.procedure
+      .input(
+        v.object({
+          visible: v.optional(v.string()),
+          secret: v.optional(v.pipe(v.string(), v.metadata({hidden: true}))),
+        }),
+      )
+      .mutation(({input}) => JSON.stringify(input)),
+  })
+
+  const help = await run(router, ['test', '--help'])
+  expect(help).toContain('--visible')
+  expect(help).not.toContain('--secret')
+
+  expect(await run(router, ['test', '--secret', 'shhh'])).toMatchInlineSnapshot(`"{"secret":"shhh"}"`)
+  expect(await run(router, ['test', '--visible', 'hi', '--secret', 'shhh'])).toMatchInlineSnapshot(
+    `"{"visible":"hi","secret":"shhh"}"`,
+  )
+})
+
+test('negatable boolean via valibot metadata', async () => {
+  const router = t.router({
+    test: t.procedure
+      .input(v.object({foo: v.pipe(v.boolean(), v.metadata({negatable: true}))}))
+      .query(({input}) => `${inspect(input)}`),
+  })
+
+  expect(await run(router, ['test', '--foo'])).toMatchInlineSnapshot(`"{ foo: true }"`)
+  expect(await run(router, ['test', '--no-foo'])).toMatchInlineSnapshot(`"{ foo: false }"`)
+  expect(await run(router, ['test', '--foo', 'true'])).toMatchInlineSnapshot(`"{ foo: true }"`)
+  expect(await run(router, ['test', '--foo', 'false'])).toMatchInlineSnapshot(`"{ foo: false }"`)
+})
+
+test('default negatable boolean can be disabled via valibot metadata', async () => {
+  const router = t.router({
+    test: t.procedure
+      .meta({negateBooleans: true})
+      .input(v.object({foo: v.boolean(), bar: v.pipe(v.boolean(), v.metadata({negatable: false}))}))
+      .query(({input}) => `${inspect(input)}`),
+  })
+
+  expect(await run(router, ['test', '--foo'])).toMatchInlineSnapshot(`"{ foo: true, bar: false }"`)
+  expect(await run(router, ['test', '--no-foo'])).toMatchInlineSnapshot(`"{ foo: false, bar: false }"`)
+  await expect(run(router, ['test', '--no-bar'])).rejects.toMatchInlineSnapshot(`
+    CLI exited with code 1
+      Caused by: CommanderError: error: unknown option '--no-bar'
+    (Did you mean one of --bar, --no-foo?)
+  `)
+})
+
 test('valibot schemas to JSON schema', async () => {
   const vtjs = await import('@valibot/to-json-schema')
   // just a test to quickly see how valibot schemas are converted to JSON schema

--- a/test/valibot.test.ts
+++ b/test/valibot.test.ts
@@ -3,6 +3,7 @@ import {inspect} from 'util'
 import * as v from 'valibot'
 import {expect, test} from 'vitest'
 import {createCli, TrpcCliMeta} from '../src/index.js'
+import {toJsonSchema as convertToJsonSchema} from '../src/json-schema.js'
 import {run, snapshotSerializer} from './test-run.js'
 
 expect.addSnapshotSerializer(snapshotSerializer)
@@ -610,6 +611,34 @@ test('alias via valibot metadata', async () => {
   expect(await run(router, ['test', '--bar', 'hello'])).toMatchInlineSnapshot(`"{"bar":"hello"}"`)
   expect(await run(router, ['test', '--bb', 'hello'])).toMatchInlineSnapshot(`"{"bar":"hello"}"`)
   expect(await run(router, ['test', '--something-else-entirely', 'hello'])).toMatchInlineSnapshot(`"{"abc":"hello"}"`)
+})
+
+test('metadata inside a nullish valibot schema', () => {
+  const result = convertToJsonSchema(
+    v.nullish(
+      v.object({
+        foo: v.pipe(v.string(), v.metadata({alias: 'f'})),
+      }),
+    ),
+    {},
+  )
+
+  expect(result).toMatchObject({
+    success: true,
+    value: {
+      optional: true,
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            foo: {type: 'string', alias: 'f'},
+          },
+          required: ['foo'],
+        },
+        {type: 'null'},
+      ],
+    },
+  })
 })
 
 test('positional via valibot metadata', async () => {


### PR DESCRIPTION
## Summary

Add support for trpc-cli-specific metadata on Valibot schemas:

- `alias`
- `positional`
- `hidden`
- `negatable`

`@valibot/to-json-schema` does not preserve custom `v.metadata(...)` values. This change reapplies those fields after conversion while retaining the converter's JSON Schema output. It handles metadata on object entries, array and tuple items, and wrapped schemas such as `optional` and `nullish`. It also mirrors Valibot object requiredness into trpc-cli's existing `optional` marker so optional positional arguments remain optional.

The README documents Valibot metadata usage alongside the existing schema examples.

## Tests

Coverage includes:

- aliases
- required and optional positional arguments
- merged procedure inputs
- variadic array positionals
- hidden options
- enabled and explicitly disabled boolean negation
- metadata inside and outside wrapper schemas

## Validation

- `pnpm build`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run test/valibot.test.ts` (42 passed)
- `NODE_NO_WARNINGS=1 pnpm test` (426 passed, 2 skipped, no type errors)
- `pnpm lint`
- `git diff --check`